### PR TITLE
speaches 0.9.0 rc has simpler docker compose setup

### DIFF
--- a/docker-compose.speaches.yml
+++ b/docker-compose.speaches.yml
@@ -32,6 +32,7 @@ services:
       WHISPER__MODEL: Systran/faster-distil-whisper-large-v3
       WHISPER__compute_type: int8_float32
       preload_models: '["Systran/faster-distil-whisper-large-v3", "speaches-ai/Kokoro-82M-v1.0-ONNX"]'
+      SPEACHES_BASE_URL: http://speaches:8000
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s


### PR DESCRIPTION
ok so in the 0.9.0-rc versions of speaches-ai, they have a preload_models setting that makes the separate speaches_init container redundant

BUT this only applies to the 0.9.0 ones, which, despite being marked as the latest in github releases, isnt the `latest` docker tag. but i just wanted to submit this

0.9.0 also has other bug fixes