### PR TITLE
fix: forward STT language from Transcribe event to Whisper API

### DIFF
--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -116,6 +116,7 @@ class OpenAIEventHandler(AsyncEventHandler):
         self._wav_write_buffer: wave.Wave_write | None = None
         self._is_recording: bool = False
         self._current_asr_model: AsrModel | None = None
+        self._current_language: str | None = None
 
         # State for event logging
         self._last_event_type: str | None = None
@@ -191,6 +192,7 @@ class OpenAIEventHandler(AsyncEventHandler):
     async def _handle_transcribe(self, transcribe: Transcribe) -> bool:
         """Handle transcription request"""
         self._current_asr_model = self._get_asr_model(transcribe.name)
+        self._current_language = transcribe.language
         if self._current_asr_model:
             if self._is_asr_language_supported(transcribe.language, self._current_asr_model):
                 return True
@@ -251,6 +253,7 @@ class OpenAIEventHandler(AsyncEventHandler):
             transcription = await self._stt_client.audio.transcriptions.create(
                 file=self._wav_buffer,
                 model=self._current_asr_model.name,
+                language=self._current_language if self._current_language is not None else omit,
                 temperature=self._stt_temperature if self._stt_temperature is not None else omit,
                 prompt=self._stt_prompt if self._stt_prompt is not None else omit,
                 response_format="json",

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -191,12 +191,18 @@ class OpenAIEventHandler(AsyncEventHandler):
 
     async def _handle_transcribe(self, transcribe: Transcribe) -> bool:
         """Handle transcription request"""
-        self._current_asr_model = self._get_asr_model(transcribe.name)
-        self._current_language = transcribe.language
-        if self._current_asr_model:
-            if self._is_asr_language_supported(transcribe.language, self._current_asr_model):
+        requested_model = self._get_asr_model(transcribe.name)
+        requested_language = transcribe.language
+
+        self._current_asr_model = None
+        self._current_language = None
+
+        if requested_model:
+            if self._is_asr_language_supported(requested_language, requested_model):
+                self._current_asr_model = requested_model
+                self._current_language = requested_language
                 return True
-            self._log_unsupported_asr_language(transcribe.name, transcribe.language)
+            self._log_unsupported_asr_language(transcribe.name, requested_language)
         else:
             self._log_unsupported_asr_model(transcribe.name)
         return False

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -458,6 +458,8 @@ class TestOpenAIEventHandlerComprehensive:
 
         # Verify transcription was called
         stt_client.audio.transcriptions.create.assert_called_once()
+        call_args = stt_client.audio.transcriptions.create.call_args[1]
+        assert call_args["language"] == "en"
 
         # Find the Transcript event in the write_event calls
         transcript_found = False
@@ -672,6 +674,54 @@ class TestOpenAIEventHandlerComprehensive:
         result = await enhanced_handler.handle_event(event)
 
         assert result is False
+        assert enhanced_handler._current_asr_model is None
+        assert enhanced_handler._current_language is None
+
+    @pytest.mark.asyncio
+    async def test_unsupported_language_does_not_call_transcription_create(self, enhanced_handler, mock_clients):
+        """Test that rejected transcription requests do not reach the STT backend."""
+        stt_client, _ = mock_clients
+        stt_client.audio.transcriptions.create = AsyncMock()
+
+        result = await enhanced_handler.handle_event(
+            Event(type="transcribe", data={"language": "zh", "name": "whisper-1"})
+        )
+
+        assert result is False
+
+        await enhanced_handler.handle_event(Event(type="audio-start", data={"rate": 16000, "width": 2, "channels": 1}))
+        await enhanced_handler.handle_event(
+            Event(type="audio-chunk", data={"rate": 16000, "width": 2, "channels": 1}, payload=b"\x00\x01" * 100)
+        )
+        await enhanced_handler.handle_event(Event(type="audio-stop"))
+
+        stt_client.audio.transcriptions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_transcribe_clears_previous_request_state(self, enhanced_handler, mock_clients):
+        """Test that a failed Transcribe request clears any previously accepted STT request."""
+        stt_client, _ = mock_clients
+        stt_client.audio.transcriptions.create = AsyncMock()
+
+        valid_result = await enhanced_handler.handle_event(
+            Event(type="transcribe", data={"language": "en", "name": "whisper-1"})
+        )
+        invalid_result = await enhanced_handler.handle_event(
+            Event(type="transcribe", data={"language": "zh", "name": "whisper-1"})
+        )
+
+        assert valid_result is True
+        assert invalid_result is False
+        assert enhanced_handler._current_asr_model is None
+        assert enhanced_handler._current_language is None
+
+        await enhanced_handler.handle_event(Event(type="audio-start", data={"rate": 16000, "width": 2, "channels": 1}))
+        await enhanced_handler.handle_event(
+            Event(type="audio-chunk", data={"rate": 16000, "width": 2, "channels": 1}, payload=b"\x00\x01" * 100)
+        )
+        await enhanced_handler.handle_event(Event(type="audio-stop"))
+
+        stt_client.audio.transcriptions.create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_audio_recording_workflow(self, enhanced_handler, mock_clients):


### PR DESCRIPTION
                                                                                                                                                                                                                            
  The language provided by the client (e.g. Home Assistant) in the Transcribe event was validated but never stored. As a result, the language parameter was omitted from the OpenAI transcription API call, causing Whisper to auto-detect   
  the language instead.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                           
  For short audio clips this often resulted in incorrect language detection — Whisper would return a translated transcript instead of a verbatim transcription in the original language (e.g. German commands being returned in English).    
                                                                                                                                                                                                                                           
  Fix: store transcribe.language in _current_language and pass it to audio.transcriptions.create() via the language= parameter.                                                                                                              
   
  Testing: Verified with a local whisper.cpp instance via Home Assistant — German (de) and French (fr) are now correctly forwarded and transcribed verbatim.                                                                                 
                                                                                                                                                                                                                   
  This fix was identified and implemented with the assistance of Claude (Anthropic) but manually reviewed and tested.