### PR TITLE
Disambiguate TTS voice names on collision (fixes #54)

### DIFF
--- a/.agents/skills/lint/SKILL.md
+++ b/.agents/skills/lint/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: lint
+description: Run all linters (ruff, pyright) and fix issues in a loop until the codebase is clean.
+disable-model-invocation: true
+---
+
+## Current State
+- Branch: !`git branch --show-current`
+- Dirty files: !`git diff --name-only`
+
+Run **all** project linters and resolve every issue. Loop until the codebase passes cleanly.
+
+### Linter pipeline
+
+Run the linters in this order each iteration:
+
+1. **Ruff auto-fix** — `ruff check . --fix` (safe, auto-fixable issues)
+2. **Ruff check** — `ruff check .` (remaining issues that need manual fixes)
+3. **Pyright** — `pyright` (type-checking)
+
+### Resolution loop
+
+```
+while linters report errors:
+    1. Run ruff check . --fix  (let ruff auto-fix what it can)
+    2. Run ruff check .
+       - If errors remain, read the offending files and fix them
+    3. Run pyright
+       - If errors remain, read the offending files and fix them
+    4. If no errors in steps 2 and 3, break
+```
+
+### Rules
+
+- **Max 5 iterations.** If issues persist after 5 loops, stop and report the remaining errors to the user.
+- **Ruff first, pyright second.** Ruff fixes (especially import sorting) can eliminate pyright false positives, so always run ruff before pyright.
+- **Use `ruff check . --fix` before manual fixes.** Never manually fix what ruff can auto-fix.
+- **Minimal changes.** Only touch lines the linters flag. Do not refactor, add docstrings, or "improve" surrounding code.
+- **Preserve behavior.** Fixes must not change runtime behavior. If a fix requires a judgment call (e.g., an `Any` type that needs a real annotation), prefer the narrowest correct type.
+- **Report clearly.** After each iteration, briefly state which linter you ran and how many errors remain. When done, summarize what was fixed.
+- If `$ARGUMENTS` contains a file path or glob, pass it to both linters to scope the run (e.g., `ruff check $ARGUMENTS` and `pyright $ARGUMENTS`).

--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from enum import Enum
 from urllib.parse import urlparse
 
@@ -23,6 +24,7 @@ class TtsVoiceModel(TtsVoice):
 
     Attributes:
         model_name (str): The name of the underlying text-to-speech model.
+        backend_voice_name (str): The raw voice identifier expected by the backend.
     """
 
     def __init__(self, model_name: str, *args, **kwargs):
@@ -34,8 +36,67 @@ class TtsVoiceModel(TtsVoice):
             *args: Variable length argument list for superclass initialization.
             **kwargs: Arbitrary keyword arguments for superclass initialization.
         """
+        backend_voice_name = kwargs.pop("backend_voice_name", None)
         super().__init__(*args, **kwargs)
         self.model_name = model_name
+        self.backend_voice_name = self.name if backend_voice_name is None else backend_voice_name
+
+
+def _get_ordered_unique_models(models: list[str], streaming_models: list[str]) -> list[str]:
+    """Return streaming-first model names while preserving input order."""
+    seen = set()
+    ordered_models = []
+
+    for model_name in streaming_models:
+        if model_name not in seen:
+            ordered_models.append(model_name)
+            seen.add(model_name)
+
+    for model_name in models:
+        if model_name not in seen:
+            ordered_models.append(model_name)
+            seen.add(model_name)
+
+    return ordered_models
+
+
+def _create_tts_voice_models(
+    model_voice_pairs: list[tuple[str, str]],
+    tts_url: str,
+    languages: list[str],
+) -> list[TtsVoiceModel]:
+    """Create Wyoming TTS voice models with collision-aware public names."""
+    if not model_voice_pairs:
+        return []
+
+    raw_name_counts = Counter(raw_voice_name for _, raw_voice_name in model_voice_pairs)
+    base_public_names = [
+        raw_voice_name if raw_name_counts[raw_voice_name] == 1 else f"{raw_voice_name} ({model_name})"
+        for model_name, raw_voice_name in model_voice_pairs
+    ]
+    public_name_counts = Counter(base_public_names)
+    duplicate_public_name_counts: Counter[str] = Counter()
+
+    voices = []
+    for (model_name, raw_voice_name), public_name in zip(model_voice_pairs, base_public_names, strict=False):
+        if public_name_counts[public_name] > 1:
+            duplicate_public_name_counts[public_name] += 1
+            public_name = f"{public_name} [{duplicate_public_name_counts[public_name]}]"
+
+        voices.append(
+            TtsVoiceModel(
+                name=public_name,
+                description=f"{raw_voice_name} ({model_name})",
+                model_name=model_name,
+                backend_voice_name=raw_voice_name,
+                attribution=Attribution(name=ATTRIBUTION_NAME_MODEL, url=tts_url),
+                installed=True,
+                languages=languages,
+                version=None,
+            )
+        )
+
+    return voices
 
 
 def create_asr_programs(
@@ -142,38 +203,9 @@ def create_tts_voices(
     Returns:
         list[TtsVoiceModel]: A list of Wyoming TtsVoiceModel instances.
     """
-    # Create ordered list: streaming models first, then non-streaming, preserving natural order and deduplicating
-    # (same pattern as create_asr_programs)
-    seen = set()
-    ordered_models = []
-
-    # Add streaming models first
-    for model_name in tts_streaming_models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
-
-    # Add non-streaming models
-    for model_name in tts_models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
-
-    voices = []
-    for model_name in ordered_models:
-        for voice in tts_voices:
-            voices.append(
-                TtsVoiceModel(
-                    name=voice,
-                    description=f"{voice} ({model_name})",
-                    model_name=model_name,
-                    attribution=Attribution(name=ATTRIBUTION_NAME_MODEL, url=tts_url),
-                    installed=True,
-                    languages=languages,
-                    version=None,
-                )
-            )
-    return voices
+    ordered_models = _get_ordered_unique_models(tts_models, tts_streaming_models)
+    model_voice_pairs = [(model_name, voice_name) for model_name in ordered_models for voice_name in tts_voices]
+    return _create_tts_voice_models(model_voice_pairs, tts_url, languages)
 
 
 def create_tts_programs(
@@ -486,23 +518,9 @@ class CustomAsyncOpenAI(AsyncOpenAI):
         Uses streaming models if regular models not specified.
         Note: this is not the list of CONFIGURED voices.
         """
-        # Use the same fallback pattern as create_asr_programs
-        seen = set()
-        ordered_models = []
+        ordered_models = _get_ordered_unique_models(model_names, streaming_model_names)
 
-        # Add streaming models first
-        for model_name in streaming_model_names:
-            if model_name not in seen:
-                ordered_models.append(model_name)
-                seen.add(model_name)
-
-        # Add non-streaming models
-        for model_name in model_names:
-            if model_name not in seen:
-                ordered_models.append(model_name)
-                seen.add(model_name)
-
-        tts_voice_models = []
+        model_voice_pairs: list[tuple[str, str]] = []
         for model_name in ordered_models:
             if self.backend == OpenAIBackend.OPENAI:
                 tts_voices = await self.list_openai_voices()
@@ -516,17 +534,9 @@ class CustomAsyncOpenAI(AsyncOpenAI):
                 _LOGGER.warning("Unknown backend: %s", self.backend)
                 continue
 
-            # Create TTS voices in Wyoming Protocol format, preserving streaming model info
-            tts_voice_models.extend(
-                create_tts_voices(
-                    tts_models=[model_name],
-                    tts_streaming_models=streaming_model_names,
-                    tts_voices=tts_voices,
-                    tts_url=str(self.base_url),
-                    languages=languages,
-                )
-            )
-        return tts_voice_models
+            model_voice_pairs.extend((model_name, voice_name) for voice_name in tts_voices)
+
+        return _create_tts_voice_models(model_voice_pairs, str(self.base_url), languages)
 
     _OPENAI_HOSTNAME = urlparse(DEFAULT_OPENAI_BASE_URL).hostname
 

--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -86,7 +86,7 @@ def _create_tts_voice_models(
         voices.append(
             TtsVoiceModel(
                 name=public_name,
-                description=f"{raw_voice_name} ({model_name})",
+                description=public_name,
                 model_name=model_name,
                 backend_voice_name=raw_voice_name,
                 attribution=Attribution(name=ATTRIBUTION_NAME_MODEL, url=tts_url),

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -367,6 +367,12 @@ class OpenAIEventHandler(AsyncEventHandler):
                     return getattr(program, "supports_synthesize_streaming", False)
         return False
 
+    def _iter_tts_voices(self):
+        """Iterate over configured TTS voices."""
+        for program in self._wyoming_info.tts:
+            for voice in program.voices:
+                yield cast(TtsVoiceModel, voice)
+
     def _get_pysbd_language(self, language: str | None) -> str:
         """
         Get pysbd-compatible language code.
@@ -626,11 +632,22 @@ class OpenAIEventHandler(AsyncEventHandler):
 
     def _get_voice(self, name: str | None = None) -> TtsVoiceModel | None:
         """Get a TTS voice by name or None"""
-        for program in self._wyoming_info.tts:
-            for voice in program.voices:
-                if not name or voice.name == name:
-                    return cast(TtsVoiceModel, voice)
+        for voice in self._iter_tts_voices():
+            if not name or voice.name == name:
+                return voice
         return None
+
+    def _get_voices_by_backend_name(self, backend_voice_name: str) -> list[TtsVoiceModel]:
+        """Get TTS voices by the raw backend voice identifier."""
+        return [
+            voice
+            for voice in self._iter_tts_voices()
+            if getattr(voice, "backend_voice_name", voice.name) == backend_voice_name
+        ]
+
+    def _get_backend_voice_name(self, voice: TtsVoice) -> str:
+        """Get the raw backend voice identifier for synthesis requests."""
+        return getattr(voice, "backend_voice_name", voice.name)
 
     def _is_tts_language_supported(self, language: str, voice: TtsVoice) -> bool:
         """Check if a language is supported by a TTS voice"""
@@ -649,16 +666,39 @@ class OpenAIEventHandler(AsyncEventHandler):
         Returns:
             TtsVoiceModel | None: The validated voice, or None if validation failed.
         """
-        # Get voice
         voice = self._get_voice(requested_voice)
-        if not voice:
+        if voice:
+            if not self._validate_tts_language(requested_language, voice):
+                return None
+            return voice
+
+        if not requested_voice:
             self._log_unsupported_voice(requested_voice)
             return None
 
-        # Validate language
-        if not self._validate_tts_language(requested_language, voice):
+        backend_matches = self._get_voices_by_backend_name(requested_voice)
+        if not backend_matches:
+            self._log_unsupported_voice(requested_voice)
             return None
 
+        if len(backend_matches) == 1:
+            voice = backend_matches[0]
+            if not self._validate_tts_language(requested_language, voice):
+                return None
+            return voice
+
+        compatible_matches = backend_matches
+        if requested_language:
+            language_matches = [
+                voice for voice in backend_matches if self._is_tts_language_supported(requested_language, voice)
+            ]
+            if language_matches:
+                compatible_matches = language_matches
+
+        voice = compatible_matches[0]
+        self._log_legacy_voice_fallback(requested_voice, voice, backend_matches)
+        if not self._validate_tts_language(requested_language, voice):
+            return None
         return voice
 
     def _validate_tts_language(self, language: str | None, voice: TtsVoice) -> bool:
@@ -680,6 +720,19 @@ class OpenAIEventHandler(AsyncEventHandler):
             _LOGGER.error(f"Voice {requested_voice} is not supported. Available voices: {available}")
         else:
             _LOGGER.error("No TTS voices specified")
+
+    def _log_legacy_voice_fallback(
+        self, requested_voice: str, selected_voice: TtsVoiceModel, matches: list[TtsVoiceModel]
+    ) -> None:
+        """Log when a legacy raw voice name falls back to a configured voice."""
+        available = [voice.name for voice in matches]
+        _LOGGER.warning(
+            "Voice %s matched multiple configured voices. Falling back to %s for backward compatibility. "
+            "Update the client to use one of: %s",
+            requested_voice,
+            selected_voice.name,
+            available,
+        )
 
     async def _handle_synthesize(self, synthesize: Synthesize) -> bool:
         """Handle text-to-speech synthesis request"""
@@ -998,7 +1051,7 @@ class OpenAIEventHandler(AsyncEventHandler):
             async with self._tts_semaphore:
                 request_kwargs = {
                     "model": voice.model_name,
-                    "voice": voice.name,
+                    "voice": self._get_backend_voice_name(voice),
                     "input": text,
                     "response_format": "wav",
                     "speed": self._tts_speed if self._tts_speed is not None else omit,
@@ -1129,7 +1182,7 @@ class OpenAIEventHandler(AsyncEventHandler):
             async with self._tts_semaphore:
                 request_kwargs = {
                     "model": voice.model_name,
-                    "voice": voice.name,
+                    "voice": self._get_backend_voice_name(voice),
                     "input": text,
                     "response_format": "wav",
                     "speed": self._tts_speed if self._tts_speed is not None else omit,

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -32,6 +32,40 @@ def test_tts_voice_model_inherits_ttsvoice():
     )
     assert isinstance(v, TtsVoice)
     assert v.model_name == "model-x"
+    assert v.backend_voice_name == "voice1"
+
+
+def test_tts_voice_model_positional_args_default_backend_voice_name():
+    v = TtsVoiceModel(
+        "model-x",
+        "voice1",
+        Attribution(name="n", url="u"),
+        True,
+        "desc",
+        "1.0",
+        ["en"],
+    )
+
+    assert isinstance(v, TtsVoice)
+    assert v.name == "voice1"
+    assert v.model_name == "model-x"
+    assert v.backend_voice_name == "voice1"
+
+
+def test_tts_voice_model_positional_args_preserve_explicit_backend_voice_name():
+    v = TtsVoiceModel(
+        "model-x",
+        "public-voice",
+        Attribution(name="n", url="u"),
+        True,
+        "desc",
+        "1.0",
+        ["en"],
+        backend_voice_name="backend-voice",
+    )
+
+    assert v.name == "public-voice"
+    assert v.backend_voice_name == "backend-voice"
 
 
 def test_create_asr_programs():
@@ -203,9 +237,9 @@ class TestCustomAsyncOpenAI:
         # Should return default OpenAI voices
         assert len(voices) == 18  # 9 voices * 2 models
         assert all(isinstance(v, TtsVoiceModel) for v in voices)
-        assert all(
-            v.name in ["alloy", "ash", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer"] for v in voices
-        )
+        alloy_voices = [v for v in voices if v.backend_voice_name == "alloy"]
+        assert len(alloy_voices) == 2
+        assert {v.name for v in alloy_voices} == {"alloy (tts-1)", "alloy (tts-1-hd)"}
 
     @pytest.mark.asyncio
     async def test_list_supported_voices_speaches(self):
@@ -324,9 +358,35 @@ class TestHelperFunctions:
 
         # Check first voice
         first_voice = result[0]
-        assert first_voice.name == "alloy"
+        assert first_voice.name == "alloy (tts-1)"
         assert first_voice.model_name == "tts-1"
+        assert first_voice.backend_voice_name == "alloy"
         assert first_voice.languages == ["en", "fr"]
+
+    def test_create_tts_voices_renames_conflicts_with_model_names(self):
+        """Test that multi-model collisions use model-specific public names."""
+        result = create_tts_voices(
+            ["model-a", "model-b"],
+            [],
+            ["shared", "echo"],
+            "https://api.openai.com",
+            ["en"],
+        )
+
+        assert [voice.name for voice in result] == [
+            "shared (model-a)",
+            "echo (model-a)",
+            "shared (model-b)",
+            "echo (model-b)",
+        ]
+        assert [voice.backend_voice_name for voice in result] == ["shared", "echo", "shared", "echo"]
+
+    def test_create_tts_voices_keeps_unique_names_when_single_model(self):
+        """Test that non-conflicting single-model voice names are unchanged."""
+        result = create_tts_voices(["tts-1"], [], ["alloy", "echo"], "https://api.openai.com", ["en"])
+
+        assert [voice.name for voice in result] == ["alloy", "echo"]
+        assert [voice.backend_voice_name for voice in result] == ["alloy", "echo"]
 
     def test_create_tts_programs_detailed(self):
         """Test creating TTS programs with actual voice models."""

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -7,6 +7,7 @@ import pytest
 from openai import omit
 from wyoming.asr import Transcript
 from wyoming.event import Event
+from wyoming.info import Attribution, TtsVoice
 from wyoming.tts import SynthesizeChunk, SynthesizeStart, SynthesizeVoice
 
 from wyoming_openai.compatibility import OpenAIBackend
@@ -28,6 +29,7 @@ def dummy_info():
             self.name = name
             self.languages = languages or ["en"]
             self.model_name = model_name or name
+            self.backend_voice_name = name
 
     class DummyProgram:
         def __init__(self, models=None, voices=None, supports_transcript_streaming=False):
@@ -485,6 +487,7 @@ def mock_info():
     tts_voice.description = "Alloy voice"
     tts_voice.languages = ["en"]
     tts_voice.model_name = "tts-1"
+    tts_voice.backend_voice_name = "alloy"
 
     # Mock TTS program
     tts_program = Mock()
@@ -1011,6 +1014,169 @@ class TestOpenAIEventHandlerComprehensive:
         assert call_args["extra_body"] == {"response_format": "pcm"}
 
     @pytest.mark.asyncio
+    async def test_handle_synthesize_uses_backend_voice_name_for_conflicts(
+        self, enhanced_handler, mock_clients, mock_info
+    ):
+        """Test synthesis uses the backend voice token when public names are model-specific."""
+        _, tts_client = mock_clients
+
+        conflicting_voice = Mock()
+        conflicting_voice.name = "alloy (tts-1)"
+        conflicting_voice.backend_voice_name = "alloy"
+        conflicting_voice.description = "alloy (tts-1)"
+        conflicting_voice.languages = ["en"]
+        conflicting_voice.model_name = "tts-1"
+        mock_info.tts[0].voices = [conflicting_voice]
+
+        wav_buffer = io.BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x00\x01" * 1000)
+        wav_buffer.seek(0)
+        mock_audio_data = wav_buffer.read()
+
+        class MockAsyncIterator:
+            def __init__(self, data):
+                self.data = data
+                self.chunks = [data[i : i + 2048] for i in range(0, len(data), 2048)]
+                self.index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.index >= len(self.chunks):
+                    raise StopAsyncIteration
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_response = Mock()
+        mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(mock_audio_data))
+
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+
+        tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+
+        event = Event(
+            type="synthesize",
+            data={"text": "Hello world", "voice": {"name": "alloy (tts-1)"}, "raw_text": "Hello world"},
+        )
+
+        assert await enhanced_handler.handle_event(event) is True
+
+        call_args = tts_client.audio.speech.with_streaming_response.create.call_args.kwargs
+        assert call_args["voice"] == "alloy"
+
+    @pytest.mark.asyncio
+    async def test_handle_synthesize_falls_back_to_voice_name_when_backend_voice_name_missing(
+        self, enhanced_handler, mock_clients, mock_info
+    ):
+        """Test synthesis remains compatible with plain Wyoming TtsVoice objects."""
+        _, tts_client = mock_clients
+
+        legacy_voice = TtsVoice(
+            name="legacy-voice",
+            description="Legacy voice",
+            attribution=Attribution(name="Test", url="https://example.com"),
+            installed=True,
+            languages=["en"],
+            version=None,
+        )
+        setattr(legacy_voice, "model_name", "tts-1")
+        mock_info.tts[0].voices = [legacy_voice]
+
+        wav_buffer = io.BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x00\x01" * 1000)
+        wav_buffer.seek(0)
+        mock_audio_data = wav_buffer.read()
+
+        class MockAsyncIterator:
+            def __init__(self, data):
+                self.data = data
+                self.chunks = [data[i : i + 2048] for i in range(0, len(data), 2048)]
+                self.index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.index >= len(self.chunks):
+                    raise StopAsyncIteration
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_response = Mock()
+        mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(mock_audio_data))
+
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+
+        tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+
+        event = Event(
+            type="synthesize",
+            data={"text": "Hello world", "voice": {"name": "legacy-voice"}, "raw_text": "Hello world"},
+        )
+
+        assert await enhanced_handler.handle_event(event) is True
+
+        call_args = tts_client.audio.speech.with_streaming_response.create.call_args.kwargs
+        assert call_args["voice"] == "legacy-voice"
+
+    def test_validate_tts_voice_and_language_falls_back_for_legacy_backend_voice(self, enhanced_handler, mock_info):
+        """Test ambiguous raw backend voice names fall back to the first configured choice."""
+        voice_a = Mock()
+        voice_a.name = "glados (model-a)"
+        voice_a.backend_voice_name = "glados"
+        voice_a.languages = ["en"]
+        voice_a.model_name = "model-a"
+
+        voice_b = Mock()
+        voice_b.name = "glados (model-b)"
+        voice_b.backend_voice_name = "glados"
+        voice_b.languages = ["en"]
+        voice_b.model_name = "model-b"
+
+        mock_info.tts[0].voices = [voice_a, voice_b]
+
+        selected_voice = enhanced_handler._validate_tts_voice_and_language("glados", None)
+
+        assert selected_voice is voice_a
+
+    def test_validate_tts_voice_and_language_prefers_language_compatible_legacy_voice(
+        self, enhanced_handler, mock_info
+    ):
+        """Test ambiguous raw backend voice names prefer a language-compatible match before falling back."""
+        voice_a = Mock()
+        voice_a.name = "glados (model-a)"
+        voice_a.backend_voice_name = "glados"
+        voice_a.languages = ["en"]
+        voice_a.model_name = "model-a"
+
+        voice_b = Mock()
+        voice_b.name = "glados (model-b)"
+        voice_b.backend_voice_name = "glados"
+        voice_b.languages = ["fr"]
+        voice_b.model_name = "model-b"
+
+        mock_info.tts[0].voices = [voice_a, voice_b]
+
+        selected_voice = enhanced_handler._validate_tts_voice_and_language("glados", "fr")
+
+        assert selected_voice is voice_b
+
+    @pytest.mark.asyncio
     async def test_handle_transcribe_with_streaming(self, enhanced_handler, mock_clients, mock_info):
         """Test handling of Transcribe event with streaming model."""
         stt_client, _ = mock_clients
@@ -1178,6 +1344,7 @@ class TestOpenAIEventHandlerComprehensive:
         voice = enhanced_handler._get_voice("alloy")
         assert voice is not None
         assert voice.name == "alloy"
+        assert voice.backend_voice_name == "alloy"
 
         # Test invalid voice
         invalid_voice = enhanced_handler._get_voice("invalid")

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1087,7 +1087,7 @@ class TestOpenAIEventHandlerComprehensive:
             languages=["en"],
             version=None,
         )
-        setattr(legacy_voice, "model_name", "tts-1")
+        legacy_voice.model_name = "tts-1"  # type: ignore[reportAttributeAccessIssue]
         mock_info.tts[0].voices = [legacy_voice]
 
         wav_buffer = io.BytesIO()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -326,9 +326,18 @@ class TestIntegration:
         # Verify all voices have correct attributes
         for voice in tts_program.voices:
             assert isinstance(voice, TtsVoiceModel)
-            assert voice.name in tts_voices
+            assert voice.backend_voice_name in tts_voices
             assert voice.model_name in tts_models
             assert voice.languages == languages
+
+        assert {voice.name for voice in tts_program.voices} == {
+            "alloy (tts-1)",
+            "echo (tts-1)",
+            "fable (tts-1)",
+            "alloy (tts-1-hd)",
+            "echo (tts-1-hd)",
+            "fable (tts-1-hd)",
+        }
 
     @pytest.mark.asyncio
     async def test_error_handling_integration(self):


### PR DESCRIPTION
## Summary

- When multiple TTS models expose the same raw voice name (e.g. several Speaches/piper models all named `glados`), voices are now disambiguated with a `(model-name)` suffix: `glados (piper-en_US-glados-high)`, `glados (piper-de_DE-glados-high)`, etc.
- The raw backend voice token is stored in a new `backend_voice_name` attribute on `TtsVoiceModel` and used for the actual OpenAI API call, so the backend receives the correct identifier regardless of the public display name.
- Legacy clients that send the old raw voice name (e.g. `glados`) still work via a backward-compatible fallback lookup in `_validate_tts_voice_and_language`.
- Single-model setups are unaffected — voice names remain unchanged when there are no collisions.
- Fixed: Home Assistant displays the `description` field in its voice dropdown, not `name`. The description now uses the same disambiguated public name instead of always including the model in parentheses — so unique voices like `glados_turret` display cleanly without a redundant model suffix.
- Added a `/lint` agent skill that runs ruff and pyright in a loop until the codebase is clean.

## Test plan

- [x] Existing tests pass (`pytest` — 118 passed)
- [x] `test_create_tts_voices_renames_conflicts_with_model_names` — verifies multi-model collision → `(model)` suffix
- [x] `test_create_tts_voices_keeps_unique_names_when_single_model` — verifies no-collision path is unchanged
- [x] `test_handle_synthesize_uses_backend_voice_name_for_conflicts` — verifies API call uses raw backend name
- [x] `test_handle_synthesize_falls_back_to_voice_name_when_backend_voice_name_missing` — verifies legacy `TtsVoice` objects still work
- [x] `test_validate_tts_voice_and_language_falls_back_for_legacy_backend_voice` — verifies raw-name fallback selects first match
- [x] `test_validate_tts_voice_and_language_prefers_language_compatible_legacy_voice` — verifies language-aware fallback
- [x] Manually verified with Speaches + 3 piper glados models via `docker-compose.issue-54.yml`

Closes #54

🤖 Generated with [Claude Code](https://claude.ai/code)