### PR TITLE
Add Python 3.13 support and adapt to openai 2.34+ credential gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,16 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13']
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
         
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ cython_debug/
 # AI
 .claude/*
 !.claude/skills
+.codex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Use an official Python runtime as a parent image
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Example: Sharing TTS/STT services between [Open WebUI](#open-webui) and [Home As
 
 ### Prerequisites
 
-- Tested with Python 3.12
+- Tested with Python 3.12 and 3.13
 - Optional: OpenAI API key(s) if using proprietary models
 
 ### Instructions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "openai==2.30.0",
-    "wyoming==1.8.0",
+    "openai==2.37.0",
+    "wyoming==1.9.0",
     "pysbd==0.3.4"
 ]
 
@@ -33,12 +33,12 @@ Issues = "https://github.com/roryeckel/wyoming_openai/issues"
 
 [project.optional-dependencies]
 dev = [
-    "ruff==0.15.8",
-    "pytest==9.0.2",
+    "ruff==0.15.13",
+    "pytest==9.0.3",
     "pytest-asyncio==1.3.0",
     "pytest-mock==3.15.1",
     "pytest-cov==7.1.0",
-    "pyright==1.1.408",
+    "pyright==1.1.409",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ include = ["wyoming_openai", "wyoming_openai.*"]
 
 [tool.pyright]
 exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/.*",
     ".git",
     ".github",
     ".venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Speech",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/src/wyoming_openai/__main__.py
+++ b/src/wyoming_openai/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import logging
 import os
+from contextlib import AsyncExitStack
 from functools import partial
 
 from wyoming.server import AsyncServer
@@ -18,7 +19,12 @@ from .compatibility import (
 )
 from .const import DEFAULT_OPENAI_BASE_URL, __version__
 from .handler import OpenAIEventHandler
-from .utilities import create_enum_parser, create_json_object_parser, validate_stt_extra_body, validate_tts_extra_body
+from .utilities import (
+    create_enum_parser,
+    create_json_object_parser,
+    validate_stt_extra_body,
+    validate_tts_extra_body,
+)
 
 
 def configure_logging(level):
@@ -226,46 +232,61 @@ async def main():
 
     _logger.info("Starting Wyoming OpenAI %s", __version__)
 
-    # Create STT factory and client
-    if args.stt_backend is None:
-        _logger.debug("STT backend is None, autodetecting...")
-        stt_factory = CustomAsyncOpenAI.create_autodetected_factory()
-    else:
-        stt_factory = CustomAsyncOpenAI.create_backend_factory(args.stt_backend)
+    if not stt_requested and not tts_requested:
+        _logger.error("No STT or TTS models specified. Exiting.")
+        return
 
-    stt_client = await stt_factory(api_key=args.stt_openai_key, base_url=args.stt_openai_url)
-    _logger.debug("Detected STT backend: %s", stt_client.backend)
+    stt_client: CustomAsyncOpenAI | None = None
+    if stt_requested:
+        if args.stt_backend is None:
+            _logger.debug("STT backend is None, autodetecting...")
+            stt_factory = CustomAsyncOpenAI.create_autodetected_factory()
+        else:
+            stt_factory = CustomAsyncOpenAI.create_backend_factory(args.stt_backend)
 
-    # Create TTS factory and client
-    if args.tts_backend is None:
-        _logger.debug("TTS backend is None, autodetecting...")
-        tts_factory = CustomAsyncOpenAI.create_autodetected_factory()
-    else:
-        tts_factory = CustomAsyncOpenAI.create_backend_factory(args.tts_backend)
+        stt_client = await stt_factory(api_key=args.stt_openai_key, base_url=args.stt_openai_url)
+        _logger.debug("Detected STT backend: %s", stt_client.backend)
 
-    tts_client = await tts_factory(api_key=args.tts_openai_key, base_url=args.tts_openai_url)
-    _logger.debug("Detected TTS backend: %s", tts_client.backend)
+    tts_client: CustomAsyncOpenAI | None = None
+    if tts_requested:
+        if args.tts_backend is None:
+            _logger.debug("TTS backend is None, autodetecting...")
+            tts_factory = CustomAsyncOpenAI.create_autodetected_factory()
+        else:
+            tts_factory = CustomAsyncOpenAI.create_backend_factory(args.tts_backend)
 
-    # Use clients in async context managers
-    async with stt_client, tts_client:
-        asr_programs = create_asr_programs(
-            args.stt_models, args.stt_streaming_models, args.stt_openai_url, args.languages
+        tts_client = await tts_factory(api_key=args.tts_openai_key, base_url=args.tts_openai_url)
+        _logger.debug("Detected TTS backend: %s", tts_client.backend)
+
+    # Use only configured clients in async context managers
+    async with AsyncExitStack() as exit_stack:
+        if stt_client is not None:
+            stt_client = await exit_stack.enter_async_context(stt_client)
+        if tts_client is not None:
+            tts_client = await exit_stack.enter_async_context(tts_client)
+
+        asr_programs = (
+            create_asr_programs(args.stt_models, args.stt_streaming_models, args.stt_openai_url, args.languages)
+            if stt_requested
+            else []
         )
 
-        if args.tts_voices:
+        if not tts_requested:
+            tts_voices = []
+        elif args.tts_voices:
             # If TTS_VOICES is set, use that
             tts_voices = create_tts_voices(
                 args.tts_models, args.tts_streaming_models, args.tts_voices, args.tts_openai_url, args.languages
             )
         else:
             # Otherwise, list supported voices via backend (with streaming fallback)
+            assert tts_client is not None
             tts_voices = await tts_client.list_supported_voices(
                 args.tts_models, args.tts_streaming_models, args.languages
             )
 
         tts_programs = create_tts_programs(tts_voices, tts_streaming_models=args.tts_streaming_models)
 
-        # Ensure at least one model is specified
         if not asr_programs and not tts_programs:
             _logger.error("No STT or TTS models specified. Exiting.")
             return

--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -3,7 +3,7 @@ from collections import Counter
 from enum import Enum
 from urllib.parse import urlparse
 
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, omit
 from wyoming.info import AsrModel, AsrProgram, Attribution, Info, TtsProgram, TtsVoice
 
 from .const import (
@@ -378,10 +378,22 @@ class CustomAsyncOpenAI(AsyncOpenAI):
     def __init__(self, *args, **kwargs):
         if "api_key" not in kwargs or not kwargs["api_key"]:
             kwargs["api_key"] = ""
+            kwargs.setdefault("_enforce_credentials", False)
         if not kwargs.get("base_url"):
             kwargs["base_url"] = DEFAULT_OPENAI_BASE_URL
         self.backend: OpenAIBackend = kwargs.pop("backend", OpenAIBackend.OPENAI)
         super().__init__(*args, **kwargs)
+
+    async def _prepare_options(self, options):
+        # Local keyless backends (Speaches, LocalAI, Kokoro) don't require auth.
+        # Without an api_key the SDK refuses to send the request unless Authorization
+        # is explicitly omitted via the Omit sentinel on the per-request headers.
+        options = await super()._prepare_options(options)
+        if not self.api_key:
+            headers = dict(options.headers or {})
+            headers.setdefault("Authorization", omit)
+            options.headers = headers
+        return options
 
     # OpenAI
 

--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -410,7 +410,7 @@ class CustomAsyncOpenAI(AsyncOpenAI):
         """
         Fetches the available audio voices from the Kokoro-FastAPI /audio/voices endpoint.
         Caution: This is not a part of official OpenAI spec.
-        Example: ["af_sky"]
+        Example Response: {"voices": ["af_sky", "af_bella", ...]}
         """
         if self.backend != OpenAIBackend.KOKORO_FASTAPI:
             _LOGGER.debug("Skipping /audio/voices request because backend is not KOKORO_FASTAPI")
@@ -420,8 +420,8 @@ class CustomAsyncOpenAI(AsyncOpenAI):
             response = await self._client.get("/audio/voices")
             response.raise_for_status()
             return response.json().get("voices", [])
-        except Exception as e:
-            _LOGGER.exception(e, "Failed to fetch /audio/voices")
+        except Exception:
+            _LOGGER.exception("Failed to fetch /audio/voices")
             raise
 
     # LocalAI
@@ -494,8 +494,8 @@ class CustomAsyncOpenAI(AsyncOpenAI):
             result = response.json()
             if "voices" in result:
                 return [voice["name"] for voice in result.get("voices", [])]
-        except Exception as e:
-            _LOGGER.exception(e, "Failed to fetch /models/%s, checking legacy endpoint...")
+        except Exception:
+            _LOGGER.exception("Failed to fetch /models/%s, checking legacy endpoint...", model_name)
 
         # LEGACY Endpoint
         # Example: [{"model_id": "hexgrad/Kokoro-82M", "voice_id": "af_sky"}]
@@ -504,8 +504,8 @@ class CustomAsyncOpenAI(AsyncOpenAI):
             response.raise_for_status()
             result = response.json()
             return [voice["voice_id"] for voice in result]
-        except Exception as e:
-            _LOGGER.exception(e, "Failed to fetch /audio/speech/voices")
+        except Exception:
+            _LOGGER.exception("Failed to fetch /audio/speech/voices")
             raise
 
     # Unified API

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -47,6 +47,7 @@ DEFAULT_ASR_AUDIO_RATE = 16000  # Hz (Wyoming default)
 TTS_AUDIO_RATE = 24000  # Hz (OpenAI spec, fallback)
 TTS_CHUNK_SIZE = 2048  # Magical guess - but must be larger than 44 bytes for a potential WAV header
 TTS_CONCURRENT_REQUESTS = 3  # Number of concurrent OpenAI TTS requests when streaming sentences
+TTS_WAV_HEADER_MAX_BYTES = 65536  # Bound header buffering if a backend never yields a complete WAV header
 
 
 @dataclass(frozen=True)
@@ -71,8 +72,8 @@ class OpenAIEventHandler(AsyncEventHandler):
         self,
         *args,
         info: Info,
-        stt_client: CustomAsyncOpenAI,
-        tts_client: CustomAsyncOpenAI,
+        stt_client: CustomAsyncOpenAI | None,
+        tts_client: CustomAsyncOpenAI | None,
         stt_temperature: float | None = None,
         stt_prompt: str | None = None,
         stt_extra_body: dict[str, object] | None = None,
@@ -89,8 +90,8 @@ class OpenAIEventHandler(AsyncEventHandler):
         Args:
             *args: Variable length argument list for the superclass.
             info (Info): The Wyoming info object.
-            stt_client (CustomAsyncOpenAI): The client for speech-to-text.
-            tts_client (CustomAsyncOpenAI): The client for text-to-speech.
+            stt_client (CustomAsyncOpenAI | None): The client for speech-to-text.
+            tts_client (CustomAsyncOpenAI | None): The client for text-to-speech.
             stt_temperature (float | None): The temperature for STT, or None for default.
             stt_prompt (str | None): An optional prompt for STT.
             stt_extra_body (dict[str, object] | None): Optional JSON body fields merged into STT requests.
@@ -257,6 +258,10 @@ class OpenAIEventHandler(AsyncEventHandler):
                 _LOGGER.warning("No ASR model set for transcription")
                 return
 
+            if self._stt_client is None:
+                _LOGGER.error("No STT client configured for transcription")
+                return
+
             # Send to OpenAI for transcription
             extra_body = self._get_stt_extra_body()
             use_streaming = get_extra_body_boolean_field(
@@ -341,7 +346,7 @@ class OpenAIEventHandler(AsyncEventHandler):
     def _get_stt_extra_body(self) -> dict[str, object] | None:
         """Get STT extra_body merged with backend-specific fields."""
         extra_body = dict(self._stt_extra_body or {})
-        if hasattr(self._stt_client, "backend") and self._stt_client.backend == OpenAIBackend.SPEACHES:
+        if self._stt_client is not None and self._stt_client.backend == OpenAIBackend.SPEACHES:
             if "vad_filter" not in extra_body:
                 extra_body["vad_filter"] = False
                 _LOGGER.debug("Adding default vad_filter=False for SPEACHES backend")
@@ -350,6 +355,17 @@ class OpenAIEventHandler(AsyncEventHandler):
     def _get_tts_extra_body(self) -> dict[str, object] | None:
         """Get TTS extra_body for request construction."""
         return dict(self._tts_extra_body) if self._tts_extra_body else None
+
+    def _get_tts_response_format(self) -> str:
+        """Get the effective TTS response format expected from the backend."""
+        if not self._tts_extra_body:
+            return "wav"
+
+        response_format = self._tts_extra_body.get("response_format")
+        if isinstance(response_format, str):
+            return response_format
+
+        return "wav"
 
     def _is_asr_model_streaming(self, model_name: str) -> bool:
         """Check if an ASR model supports streaming"""
@@ -1037,6 +1053,9 @@ class OpenAIEventHandler(AsyncEventHandler):
             # Check if this task is allowed to stream directly
             should_stream = task_id is not None and task_id == self._allow_streaming_task_id
 
+            if self._tts_client is None:
+                raise TtsStreamError("TTS client is not configured", chunk_preview, voice.name)
+
             if should_stream:
                 # Stream directly to Wyoming (no buffering) - minimal latency
                 _LOGGER.debug("Streaming chunk directly (task %s): %s", task_id, chunk_preview)
@@ -1177,11 +1196,16 @@ class OpenAIEventHandler(AsyncEventHandler):
             float | None: Final timestamp after streaming, or None on error.
         """
         try:
-            first_chunk = None
             audio_rate = TTS_AUDIO_RATE
             audio_width = DEFAULT_AUDIO_WIDTH
             audio_channels = DEFAULT_AUDIO_CHANNELS
             timestamp = start_timestamp
+            awaiting_wav_header = self._get_tts_response_format() == "wav"
+            pending_header = b""
+
+            if self._tts_client is None:
+                _LOGGER.error("No TTS client configured for synthesis")
+                return None
 
             async with self._tts_semaphore:
                 request_kwargs = {
@@ -1197,15 +1221,14 @@ class OpenAIEventHandler(AsyncEventHandler):
 
                 async with self._tts_client.audio.speech.with_streaming_response.create(**request_kwargs) as response:
                     async for chunk in response.iter_bytes(chunk_size=TTS_CHUNK_SIZE):
-                        if first_chunk is None:
-                            # First chunk: parse WAV header and send AudioStart
-                            first_chunk = chunk
-
-                            # Try to parse WAV header from first chunk
-                            wav_params = self._parse_wav_header(chunk)
+                        if awaiting_wav_header:
+                            pending_header += chunk
+                            wav_params = self._parse_wav_header(pending_header)
                             if wav_params:
                                 audio_rate, audio_channels, audio_width, data_offset = wav_params
-                                audio_data = chunk[data_offset:]
+                                audio_data = pending_header[data_offset:]
+                                pending_header = b""
+                                awaiting_wav_header = False
                                 _LOGGER.debug(
                                     "Detected audio format: %d Hz, %d channels, %d bytes/sample, header offset: %d",
                                     audio_rate,
@@ -1213,21 +1236,26 @@ class OpenAIEventHandler(AsyncEventHandler):
                                     audio_width,
                                     data_offset,
                                 )
+                            elif len(pending_header) <= TTS_WAV_HEADER_MAX_BYTES:
+                                continue
                             else:
-                                _LOGGER.debug("Could not parse WAV header, using defaults: %d Hz", TTS_AUDIO_RATE)
-                                audio_data = chunk
-
-                            # Send audio start only once
-                            if send_audio_start:
-                                await self.write_event(
-                                    AudioStart(rate=audio_rate, width=audio_width, channels=audio_channels).event()
+                                _LOGGER.warning(
+                                    "Could not parse WAV header after buffering %d bytes, falling back to raw PCM",
+                                    len(pending_header),
                                 )
-                                send_audio_start = False  # Prevent re-sending AudioStart
+                                audio_data = pending_header
+                                pending_header = b""
+                                awaiting_wav_header = False
                         else:
-                            # Subsequent chunks: no header to strip
                             audio_data = chunk
 
-                        # Send audio chunk (header stripped for first chunk)
+                        if send_audio_start:
+                            await self.write_event(
+                                AudioStart(rate=audio_rate, width=audio_width, channels=audio_channels).event()
+                            )
+                            send_audio_start = False
+
+                        # Send audio chunk after any buffered WAV header bytes have been removed.
                         if audio_data:
                             await self.write_event(
                                 AudioChunk(
@@ -1245,6 +1273,32 @@ class OpenAIEventHandler(AsyncEventHandler):
                                 audio_width=audio_width,
                                 audio_channels=audio_channels,
                             )
+
+            if awaiting_wav_header and pending_header:
+                _LOGGER.warning(
+                    "TTS response ended before a complete WAV header was available, falling back to raw PCM"
+                )
+                if send_audio_start:
+                    await self.write_event(
+                        AudioStart(rate=audio_rate, width=audio_width, channels=audio_channels).event()
+                    )
+
+                await self.write_event(
+                    AudioChunk(
+                        audio=pending_header,
+                        rate=audio_rate,
+                        width=audio_width,
+                        channels=audio_channels,
+                        timestamp=int(timestamp),
+                    ).event()
+                )
+                timestamp = self._advance_audio_timestamp(
+                    timestamp,
+                    audio_data=pending_header,
+                    audio_rate=audio_rate,
+                    audio_width=audio_width,
+                    audio_channels=audio_channels,
+                )
 
             return timestamp
 

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -1127,9 +1127,13 @@ class OpenAIEventHandler(AsyncEventHandler):
                         timestamp=int(timestamp),
                     ).event()
                 )
-                # Calculate timestamp increment based on actual audio data length
-                actual_samples = len(audio_data) // audio_width
-                timestamp += (actual_samples / audio_rate) * 1000
+                timestamp = self._advance_audio_timestamp(
+                    timestamp,
+                    audio_data=audio_data,
+                    audio_rate=audio_rate,
+                    audio_width=audio_width,
+                    audio_channels=audio_channels,
+                )
 
             return timestamp
 
@@ -1234,15 +1238,36 @@ class OpenAIEventHandler(AsyncEventHandler):
                                     timestamp=int(timestamp),
                                 ).event()
                             )
-                            # Calculate timestamp increment based on actual audio data length
-                            actual_samples = len(audio_data) // audio_width
-                            timestamp += (actual_samples / audio_rate) * 1000
+                            timestamp = self._advance_audio_timestamp(
+                                timestamp,
+                                audio_data=audio_data,
+                                audio_rate=audio_rate,
+                                audio_width=audio_width,
+                                audio_channels=audio_channels,
+                            )
 
             return timestamp
 
         except Exception as e:
             _LOGGER.exception("Error streaming TTS audio: %s", e)
             return None
+
+    def _advance_audio_timestamp(
+        self,
+        timestamp: float,
+        *,
+        audio_data: bytes,
+        audio_rate: int,
+        audio_width: int,
+        audio_channels: int,
+    ) -> float:
+        """Advance a Wyoming audio timestamp using PCM frame count."""
+        frame_size = audio_width * audio_channels
+        if frame_size <= 0:
+            return timestamp
+
+        actual_frames = len(audio_data) // frame_size
+        return timestamp + (actual_frames / audio_rate) * 1000
 
     def _parse_wav_header(self, wav_data: bytes) -> tuple[int, int, int, int] | None:
         """

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -170,9 +170,9 @@ async def test_keyless_request_omits_authorization(monkeypatch):
             "Opts",
             (),
             {"headers": None, "security": None},
-        )()
+        )()  # type: ignore[reportArgumentType]
     )
-    assert isinstance(options.headers["Authorization"], Omit)
+    assert isinstance(options.headers["Authorization"], Omit)  # type: ignore[reportIndexIssue]
 
 
 class TestOpenAIBackend:

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -132,6 +132,49 @@ def test_custom_async_openai_init_sets_backend(monkeypatch):
     assert c.backend == OpenAIBackend.SPEACHES
 
 
+@pytest.mark.asyncio
+async def test_keyless_request_omits_authorization(monkeypatch):
+    """Keyless local backends (Speaches/LocalAI/Kokoro) must reach the wire
+    without an Authorization header — openai>=2.34 otherwise refuses to send
+    the request. Guards [compatibility.py] _prepare_options injection."""
+    from openai import APIConnectionError, Omit
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+
+    captured: dict = {}
+
+    async def fake_send(self, request, **kwargs):
+        captured["headers"] = dict(request.headers)
+        raise APIConnectionError(request=request)
+
+    monkeypatch.setattr("httpx.AsyncClient.send", fake_send)
+
+    client = CustomAsyncOpenAI(
+        backend=OpenAIBackend.SPEACHES,
+        base_url="http://127.0.0.1:9/v1",
+    )
+    assert client.api_key == ""
+
+    with pytest.raises(APIConnectionError):
+        await client.audio.transcriptions.create(
+            model="whisper-1", file=("x.wav", b"RIFF")
+        )
+
+    # Authorization must not be sent on the wire for keyless backends.
+    assert "authorization" not in captured["headers"]
+
+    # The Omit sentinel must be exposed on per-request options for SDK validation.
+    options = await client._prepare_options(
+        type(
+            "Opts",
+            (),
+            {"headers": None, "security": None},
+        )()
+    )
+    assert isinstance(options.headers["Authorization"], Omit)
+
+
 class TestOpenAIBackend:
     """Test OpenAIBackend enum."""
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -949,6 +949,62 @@ class TestOpenAIEventHandlerComprehensive:
         assert timestamp == pytest.approx(1000.0)
 
     @pytest.mark.asyncio
+    async def test_stream_tts_audio_buffers_fragmented_wav_header(self, enhanced_handler, mock_clients):
+        """Test fragmented WAV headers are buffered without breaking stereo timestamps."""
+        _, tts_client = mock_clients
+
+        wav_buffer = io.BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(2)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x00\x01\x02\x03" * 1000)
+        wav_buffer.seek(0)
+        wav_data = wav_buffer.read()
+
+        fragmented_chunks = [wav_data[:20], wav_data[20:60], wav_data[60:]]
+
+        class MockAsyncIterator:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.index >= len(self.chunks):
+                    raise StopAsyncIteration
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_response = Mock()
+        mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(fragmented_chunks))
+
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+
+        tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+
+        voice = enhanced_handler._get_voice("alloy")
+        assert voice is not None
+
+        enhanced_handler.write_event.reset_mock()
+        timestamp = await enhanced_handler._stream_tts_audio(voice, "Hello world", send_audio_start=True)
+
+        expected_frames = (len(wav_data) - 44) // (2 * 2)
+        assert timestamp == pytest.approx(expected_frames / 24000 * 1000)
+
+        audio_chunk_events = [
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "audio-chunk"
+        ]
+        assert audio_chunk_events
+        assert audio_chunk_events[0].payload == wav_data[44:60]
+        assert b"".join(event.payload for event in audio_chunk_events) == wav_data[44:]
+
+    @pytest.mark.asyncio
     async def test_handle_streaming_synthesis(self, enhanced_handler, mock_clients):
         """Test handling of streaming synthesis events."""
         _, tts_client = mock_clients

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -884,6 +884,71 @@ class TestOpenAIEventHandlerComprehensive:
         assert call_args["extra_body"] == {"response_format": "pcm"}
 
     @pytest.mark.asyncio
+    async def test_stream_audio_to_wyoming_uses_frame_count_for_stereo_audio(self, enhanced_handler):
+        """Test stereo audio timestamps are based on PCM frames, not per-channel samples."""
+        wav_buffer = io.BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(2)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x00\x01\x02\x03" * 24000)
+        wav_buffer.seek(0)
+
+        timestamp = await enhanced_handler._stream_audio_to_wyoming(
+            wav_buffer.read(),
+            is_first_chunk=True,
+            start_timestamp=0,
+        )
+
+        assert timestamp == pytest.approx(1000.0)
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_audio_uses_frame_count_for_stereo_audio(self, enhanced_handler, mock_clients):
+        """Test direct TTS streaming preserves correct stereo timing."""
+        _, tts_client = mock_clients
+
+        wav_buffer = io.BytesIO()
+        with wave.open(wav_buffer, "wb") as wav_file:
+            wav_file.setnchannels(2)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(24000)
+            wav_file.writeframes(b"\x00\x01\x02\x03" * 24000)
+        wav_buffer.seek(0)
+        mock_audio_data = wav_buffer.read()
+
+        class MockAsyncIterator:
+            def __init__(self, data):
+                self.data = data
+                self.chunks = [data]
+                self.index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.index >= len(self.chunks):
+                    raise StopAsyncIteration
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        mock_response = Mock()
+        mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(mock_audio_data))
+
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+
+        tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+
+        voice = enhanced_handler._get_voice("alloy")
+        assert voice is not None
+
+        timestamp = await enhanced_handler._stream_tts_audio(voice, "Hello world", send_audio_start=True)
+
+        assert timestamp == pytest.approx(1000.0)
+
+    @pytest.mark.asyncio
     async def test_handle_streaming_synthesis(self, enhanced_handler, mock_clients):
         """Test handling of streaming synthesis events."""
         _, tts_client = mock_clients

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -215,8 +215,11 @@ class _FakeClient:
 
 
 class _CapturingServer:
+    def __init__(self):
+        self.handlers = []
+
     async def run(self, handler_factory):
-        handler_factory(Mock(name="reader"), Mock(name="writer"))
+        self.handlers.append(handler_factory(Mock(name="reader"), Mock(name="writer")))
 
 
 @pytest.mark.asyncio
@@ -285,3 +288,83 @@ async def test_main_allows_unused_stt_response_format_in_tts_only_mode(monkeypat
     )
 
     await main()
+
+
+@pytest.mark.asyncio
+async def test_main_skips_tts_client_creation_in_stt_only_mode(monkeypatch):
+    server = _CapturingServer()
+    factory_calls = []
+
+    async def fake_factory(*args, **kwargs):
+        factory_calls.append(kwargs)
+        return _FakeClient()
+
+    monkeypatch.setattr(
+        main_module.CustomAsyncOpenAI,
+        "create_autodetected_factory",
+        staticmethod(lambda: fake_factory),
+    )
+    monkeypatch.setattr(
+        main_module.AsyncServer,
+        "from_uri",
+        staticmethod(lambda uri: server),
+    )
+    for env_var in ("TTS_MODELS", "TTS_STREAMING_MODELS", "TTS_VOICES"):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wyoming_openai",
+            "--stt-models",
+            "whisper-1",
+        ],
+    )
+
+    await main()
+
+    assert len(factory_calls) == 1
+    assert len(server.handlers) == 1
+    assert server.handlers[0]._stt_client is not None
+    assert server.handlers[0]._tts_client is None
+
+
+@pytest.mark.asyncio
+async def test_main_skips_stt_client_creation_in_tts_only_mode(monkeypatch):
+    server = _CapturingServer()
+    factory_calls = []
+
+    async def fake_factory(*args, **kwargs):
+        factory_calls.append(kwargs)
+        return _FakeClient()
+
+    monkeypatch.setattr(
+        main_module.CustomAsyncOpenAI,
+        "create_autodetected_factory",
+        staticmethod(lambda: fake_factory),
+    )
+    monkeypatch.setattr(
+        main_module.AsyncServer,
+        "from_uri",
+        staticmethod(lambda uri: server),
+    )
+    for env_var in ("STT_MODELS", "STT_STREAMING_MODELS"):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wyoming_openai",
+            "--tts-models",
+            "tts-1",
+            "--tts-voices",
+            "alloy",
+        ],
+    )
+
+    await main()
+
+    assert len(factory_calls) == 1
+    assert len(server.handlers) == 1
+    assert server.handlers[0]._stt_client is None
+    assert server.handlers[0]._tts_client is not None


### PR DESCRIPTION
## Summary
- Add Python 3.13 to CI matrix, Dockerfile, classifiers, and README; bump `openai` 2.30→2.37 and `wyoming` 1.8→1.9.
- Work around the credential checks introduced in openai 2.34+ so keyless local backends (Speaches, LocalAI, Kokoro) keep working: pass `_enforce_credentials=False` at construction and inject the `Omit` sentinel into per-request `Authorization` headers via `_prepare_options`.
- Support STT-only and TTS-only deployments by skipping client creation for the unused side, and buffer streaming TTS chunks until a complete WAV header is parseable so fragmented headers no longer leak into the first audio chunk or produce wrong `AudioStart` format.
- Fix stereo TTS streaming timestamps by computing from PCM frame count (`width * channels`) via a shared helper instead of dividing by sample width alone.
- Minor: correct `Logger.exception()` misuse in compatibility.py, silence pyright noise in tests, and ignore venv/cache dirs.

## Test plan
- [ ] `pytest` passes on Python 3.12 and 3.13
- [ ] `ruff check .` clean
- [ ] `pyright` clean
- [ ] Smoke-test a keyless backend (Speaches or LocalAI) end-to-end for both STT and TTS
- [ ] Smoke-test STT-only and TTS-only startup modes
- [ ] Verify stereo TTS playback timing in Home Assistant
- [ ] Docker image builds on `python:3.13-slim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)