### PR TITLE
Fix Kokoro FastAPI voice catalog parsing

### DIFF
--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -99,6 +99,31 @@ def _create_tts_voice_models(
     return voices
 
 
+def _extract_voice_names(result: object) -> list[str]:
+    """Extract backend voice identifiers from common voice-list response shapes."""
+    voices = result.get("voices", []) if isinstance(result, dict) else result
+
+    if not isinstance(voices, list):
+        _LOGGER.warning("Unexpected voices response shape: %s", type(voices).__name__)
+        return []
+
+    voice_names = []
+    for voice in voices:
+        if isinstance(voice, str):
+            voice_names.append(voice)
+            continue
+
+        if isinstance(voice, dict):
+            voice_name = voice.get("id") or voice.get("name")
+            if isinstance(voice_name, str):
+                voice_names.append(voice_name)
+                continue
+
+        _LOGGER.warning("Skipping unexpected voice entry: %r", voice)
+
+    return voice_names
+
+
 def create_asr_programs(
     stt_models: list[str],
     stt_streaming_models: list[str],
@@ -422,7 +447,9 @@ class CustomAsyncOpenAI(AsyncOpenAI):
         """
         Fetches the available audio voices from the Kokoro-FastAPI /audio/voices endpoint.
         Caution: This is not a part of official OpenAI spec.
-        Example Response: {"voices": ["af_sky", "af_bella", ...]}
+        Example legacy response: ["af_sky", "af_bella", ...]
+        Example old response: {"voices": ["af_sky", "af_bella", ...]}
+        Example current response: [{"id": "af_sky", "name": "Sky"}, ...]
         """
         if self.backend != OpenAIBackend.KOKORO_FASTAPI:
             _LOGGER.debug("Skipping /audio/voices request because backend is not KOKORO_FASTAPI")
@@ -431,7 +458,7 @@ class CustomAsyncOpenAI(AsyncOpenAI):
         try:
             response = await self._client.get("/audio/voices")
             response.raise_for_status()
-            return response.json().get("voices", [])
+            return _extract_voice_names(response.json())
         except Exception:
             _LOGGER.exception("Failed to fetch /audio/voices")
             raise

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -508,3 +508,35 @@ class TestBackendSpecificBehavior:
             assert all(set(v.languages) == {"en", "ja"} for v in voices)
             assert voices[0].name == "af_sky"
             assert voices[1].name == "bf_emma"
+
+    @pytest.mark.asyncio
+    async def test_kokoro_fastapi_voice_endpoint_accepts_new_catalog_shape(self):
+        """Test Kokoro FastAPI voice listing with the current catalog response shape."""
+        custom_client = CustomAsyncOpenAI(api_key="test-key", backend=OpenAIBackend.KOKORO_FASTAPI)
+        response = Mock()
+        response.json.return_value = [
+            {"id": "af_sky", "name": "Sky"},
+            {"id": "bf_emma", "name": "Emma"},
+        ]
+        response.raise_for_status.return_value = None
+
+        with patch.object(custom_client._client, "get", AsyncMock(return_value=response)) as mock_get:
+            voices = await custom_client._list_kokoro_fastapi_voices()
+
+        assert voices == ["af_sky", "bf_emma"]
+        mock_get.assert_awaited_once_with("/audio/voices")
+
+    @pytest.mark.asyncio
+    async def test_kokoro_fastapi_voice_endpoint_accepts_legacy_shapes(self):
+        """Test Kokoro FastAPI voice listing with legacy string-list response shapes."""
+        custom_client = CustomAsyncOpenAI(api_key="test-key", backend=OpenAIBackend.KOKORO_FASTAPI)
+
+        for payload in (["af_sky", "bf_emma"], {"voices": ["af_sky", "bf_emma"]}):
+            response = Mock()
+            response.json.return_value = payload
+            response.raise_for_status.return_value = None
+
+            with patch.object(custom_client._client, "get", AsyncMock(return_value=response)):
+                voices = await custom_client._list_kokoro_fastapi_voices()
+
+            assert voices == ["af_sky", "bf_emma"]


### PR DESCRIPTION
Closes #63.

Summary:
- Parse Kokoro /audio/voices responses returned as the current object catalog.
- Preserve compatibility with legacy string-list and wrapped string-list responses.
- Keep using the default endpoint shape instead of requesting legacy mode.
- Add regression tests for current and legacy voice response shapes.

Verification:
- User tested successfully with Kokoro-FastAPI.
- pytest tests/test_compatibility.py
- pytest tests
- ruff check .
- pyright --pythonpath .venv/Scripts/python.exe