### PR TITLE
Add OpenAI Realtime transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project introduces a [Wyoming](https://github.com/OHF-Voice/wyoming) server
 This project features a variety of examples for using cutting-edge models in both Speech-to-Text (STT) and Text-to-Speech (TTS) scenarios:
 
 - **`gpt-4o-transcribe`**: OpenAI's latest and most advanced model for highly accurate speech recognition.
+- **`gpt-realtime-whisper`**: OpenAI's recommended low-latency realtime transcription model for live audio and transcript deltas.
 - **`gpt-4o-mini-tts`**: A compact and efficient text-to-speech model from OpenAI, perfect for responsive vocalization.
 - **`voxtral-mini-latest`**: Mistral AI's multilingual Voxtral ASR, built for long-form audio (32k token context) and tested on up to ~30 minutes per file, available via [Mistral AI](#5-deploying-with-mistral-ai-voxtral) or self-hosted open weights.
 - **`kokoro`**: A high-quality, open-source text-to-speech model, available for local deployment via [Speaches](#2-deploying-with-speaches-local-service) and [Kokoro-FastAPI](#4-deploying-with-kokoro-fastapi-and-speaches-local-services).
@@ -138,6 +139,7 @@ python -m wyoming_openai \
   --stt-openai-url https://api.openai.com/v1 \
   --stt-models whisper-1 \
   --stt-streaming-models gpt-4o-transcribe gpt-4o-mini-transcribe \
+  --stt-realtime-models gpt-realtime-whisper \
   --stt-backend OPENAI \
   --tts-openai-key YOUR_TTS_API_KEY_HERE \
   --tts-openai-url https://api.openai.com/v1 \
@@ -163,6 +165,7 @@ In addition to using command-line arguments, you can configure the Wyoming OpenA
 | `--stt-openai-url`                      | `STT_OPENAI_URL`                           | https://api.openai.com/v1                     | The base URL for the OpenAI-compatible speech-to-text API            |
 | `--stt-models`                          | `STT_MODELS`                               | None (required*)                                          | Space-separated list of models to use for the STT service. Example: `gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1` |
 | `--stt-streaming-models`                | `STT_STREAMING_MODELS`                     | None                                          | Space-separated list of STT models that support streaming (e.g. `gpt-4o-transcribe gpt-4o-mini-transcribe`). Only these models will use streaming mode. |
+| `--stt-realtime-models`                 | `STT_REALTIME_MODELS`                      | None                                          | Space-separated list of STT models that use OpenAI Realtime transcription sessions (e.g. `gpt-realtime-whisper`). These models stream audio over `/v1/realtime` and emit Wyoming `TranscriptChunk` deltas before the final transcript. |
 | `--stt-backend`                         | `STT_BACKEND`                              | None (autodetected)                           | Enable unofficial API feature sets.          |
 | `--stt-temperature`                     | `STT_TEMPERATURE`                          | None (autodetected)                           | Sampling temperature for speech-to-text (ranges from 0.0 to 1.0)               |
 | `--stt-prompt`                          | `STT_PROMPT`                               | None                                          | Optional prompt for STT requests (Text to guide the model's style).   |
@@ -179,7 +182,9 @@ In addition to using command-line arguments, you can configure the Wyoming OpenA
 | `--tts-streaming-min-words`             | `TTS_STREAMING_MIN_WORDS`                  | None                                          | Minimum words per text chunk for incremental TTS streaming (optional). |
 | `--tts-streaming-max-chars`             | `TTS_STREAMING_MAX_CHARS`                  | None                                          | Maximum characters per text chunk for incremental TTS streaming (optional). |
 
-Both `STT_EXTRA_BODY` and `TTS_EXTRA_BODY` must be valid JSON objects. The OpenAI client merges these values into the outgoing request body rather than sending a nested `extra_body` field. Supported overlaps still need to match Wyoming's transport expectations: STT continues to require `response_format="json"`, and a boolean `stream` override will update both the request body and the client's response parser. TTS can override raw-audio fields such as `response_format`, `speed`, and `instructions`, but rejects `stream` and `stream_format` because the handler expects audio bytes instead of SSE-style framing.
+`STT_STREAMING_MODELS` and `STT_REALTIME_MODELS` select different STT transports. `STT_STREAMING_MODELS` still uses `/v1/audio/transcriptions` with response streaming after Wyoming `AudioStop`. `STT_REALTIME_MODELS` opens a `/v1/realtime` transcription session, sends 24 kHz mono PCM16 audio chunks as Wyoming audio arrives, commits on Wyoming `AudioStop`, and emits `TranscriptChunk` deltas plus a final `Transcript`.
+
+Both `STT_EXTRA_BODY` and `TTS_EXTRA_BODY` must be valid JSON objects. The OpenAI client merges these values into the outgoing request body rather than sending a nested `extra_body` field. Supported overlaps still need to match Wyoming's transport expectations: STT continues to require `response_format="json"`, and a boolean `stream` override will update both the request body and the client's response parser for `/v1/audio/transcriptions`. TTS can override raw-audio fields such as `response_format`, `speed`, and `instructions`, but rejects `stream` and `stream_format` because the handler expects audio bytes instead of SSE-style framing.
 
 ## Docker (Recommended) [![Docker Image CI](https://github.com/roryeckel/wyoming-openai/actions/workflows/docker-image.yml/badge.svg)](https://github.com/roryeckel/wyoming-openai/actions/workflows/docker-image.yml)
 

--- a/README.md
+++ b/README.md
@@ -525,12 +525,6 @@ sequenceDiagram
     
 ```
 
-## Future Plans (Descending Priority)
-
-- Improved streaming support directly to OpenAI APIs
-- Reverse direction support (Server for OpenAI compatible endpoints - possibly FastAPI)
-- OpenAI Realtime API
-
 ## Contributing
 
 Contributions are welcome! Please feel free to open issues or submit pull requests. For major changes, please first discuss the proposed changes in an issue.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project introduces a [Wyoming](https://github.com/OHF-Voice/wyoming) server
 
 This project features a variety of examples for using cutting-edge models in both Speech-to-Text (STT) and Text-to-Speech (TTS) scenarios:
 
-- **`gpt-4o-transcribe`**: OpenAI's latest and most advanced model for highly accurate speech recognition.
+- **`gpt-4o-transcribe`**: OpenAI's latest and most advanced model for highly accurate speech recognition; it can also be used in OpenAI Realtime transcription sessions.
 - **`gpt-realtime-whisper`**: OpenAI's recommended low-latency realtime transcription model for live audio and transcript deltas.
 - **`gpt-4o-mini-tts`**: A compact and efficient text-to-speech model from OpenAI, perfect for responsive vocalization.
 - **`voxtral-mini-latest`**: Mistral AI's multilingual Voxtral ASR, built for long-form audio (32k token context) and tested on up to ~30 minutes per file, available via [Mistral AI](#5-deploying-with-mistral-ai-voxtral) or self-hosted open weights.
@@ -139,7 +139,7 @@ python -m wyoming_openai \
   --stt-openai-url https://api.openai.com/v1 \
   --stt-models whisper-1 \
   --stt-streaming-models gpt-4o-transcribe gpt-4o-mini-transcribe \
-  --stt-realtime-models gpt-realtime-whisper \
+  --stt-realtime-models gpt-realtime-whisper gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1 \
   --stt-backend OPENAI \
   --tts-openai-key YOUR_TTS_API_KEY_HERE \
   --tts-openai-url https://api.openai.com/v1 \
@@ -165,7 +165,7 @@ In addition to using command-line arguments, you can configure the Wyoming OpenA
 | `--stt-openai-url`                      | `STT_OPENAI_URL`                           | https://api.openai.com/v1                     | The base URL for the OpenAI-compatible speech-to-text API            |
 | `--stt-models`                          | `STT_MODELS`                               | None (required*)                                          | Space-separated list of models to use for the STT service. Example: `gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1` |
 | `--stt-streaming-models`                | `STT_STREAMING_MODELS`                     | None                                          | Space-separated list of STT models that support streaming (e.g. `gpt-4o-transcribe gpt-4o-mini-transcribe`). Only these models will use streaming mode. |
-| `--stt-realtime-models`                 | `STT_REALTIME_MODELS`                      | None                                          | Space-separated list of STT models that use OpenAI Realtime transcription sessions (e.g. `gpt-realtime-whisper`). These models stream audio over `/v1/realtime` and emit Wyoming `TranscriptChunk` deltas before the final transcript. |
+| `--stt-realtime-models`                 | `STT_REALTIME_MODELS`                      | None                                          | Space-separated list of STT models that use OpenAI Realtime transcription sessions (e.g. `gpt-realtime-whisper gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1`). These models stream audio over `/v1/realtime` and emit Wyoming `TranscriptChunk` deltas before the final transcript. |
 | `--stt-backend`                         | `STT_BACKEND`                              | None (autodetected)                           | Enable unofficial API feature sets.          |
 | `--stt-temperature`                     | `STT_TEMPERATURE`                          | None (autodetected)                           | Sampling temperature for speech-to-text (ranges from 0.0 to 1.0)               |
 | `--stt-prompt`                          | `STT_PROMPT`                               | None                                          | Optional prompt for STT requests (Text to guide the model's style).   |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ In addition to using command-line arguments, you can configure the Wyoming OpenA
 | `--stt-openai-url`                      | `STT_OPENAI_URL`                           | https://api.openai.com/v1                     | The base URL for the OpenAI-compatible speech-to-text API            |
 | `--stt-models`                          | `STT_MODELS`                               | None (required*)                                          | Space-separated list of models to use for the STT service. Example: `gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1` |
 | `--stt-streaming-models`                | `STT_STREAMING_MODELS`                     | None                                          | Space-separated list of STT models that support streaming (e.g. `gpt-4o-transcribe gpt-4o-mini-transcribe`). Only these models will use streaming mode. |
-| `--stt-realtime-models`                 | `STT_REALTIME_MODELS`                      | None                                          | Space-separated list of STT models that use OpenAI Realtime transcription sessions (e.g. `gpt-realtime-whisper gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1`). These models stream audio over `/v1/realtime` and emit Wyoming `TranscriptChunk` deltas before the final transcript. |
+| `--stt-realtime-models`                 | `STT_REALTIME_MODELS`                      | None                                          | Space-separated list of STT models that use OpenAI Realtime transcription sessions (e.g. `gpt-realtime-whisper gpt-4o-transcribe gpt-4o-mini-transcribe whisper-1`). These models stream audio over `/v1/realtime` and emit Wyoming `TranscriptChunk` deltas before the final transcript. Not commonly supported by community projects. |
 | `--stt-backend`                         | `STT_BACKEND`                              | None (autodetected)                           | Enable unofficial API feature sets.          |
 | `--stt-temperature`                     | `STT_TEMPERATURE`                          | None (autodetected)                           | Sampling temperature for speech-to-text (ranges from 0.0 to 1.0)               |
 | `--stt-prompt`                          | `STT_PROMPT`                               | None                                          | Optional prompt for STT requests (Text to guide the model's style).   |
@@ -383,9 +383,9 @@ We follow specific tagging conventions for our Docker images. These tags help in
 
 - **`main`**: This tag points to the latest commit on the main code branch. It is suitable for users who want to experiment with the most up-to-date features and changes, but may include unstable or experimental code.
 
-- **`major.minor.patch version`**: Specific version tags (e.g., `0.4.4`) correspond to specific stable releases of the Wyoming OpenAI proxy server. These tags are ideal for users who need a consistent, reproducible environment and want to avoid breaking changes introduced in newer versions.
+- **`major.minor.patch version`**: Specific version tags (e.g., `0.5.0`) correspond to specific stable releases of the Wyoming OpenAI proxy server. These tags are ideal for users who need a consistent, reproducible environment and want to avoid breaking changes introduced in newer versions.
 
-- **`major.minor version`**: Tags that follow the `major.minor` format (e.g., `0.4`) represent a range of patch-level updates within the same minor version series. These tags are useful for users who want to stay updated with bug fixes and minor improvements without upgrading to a new major or minor version.
+- **`major.minor version`**: Tags that follow the `major.minor` format (e.g., `0.5`) represent a range of patch-level updates within the same minor version series. These tags are useful for users who want to stay updated with bug fixes and minor improvements without upgrading to a new major or minor version.
 
 - **`pr-{number}`**: Pull request tags (e.g., `pr-123`) are automatically created for each pull request to allow testing of proposed changes before they are merged. These tags are automatically cleaned up when the pull request is closed or merged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wyoming_openai"
-version = "0.4.4"
+version = "0.5.0"
 description = "OpenAI-Compatible Proxy Middleware for the Wyoming Protocol"
 authors = [
     { name = "Rory Eckel" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "openai==2.37.0",
+    "openai[realtime]==2.37.0",
     "wyoming==1.9.0",
     "pysbd==0.3.4"
 ]

--- a/src/wyoming_openai/__main__.py
+++ b/src/wyoming_openai/__main__.py
@@ -142,6 +142,12 @@ async def main():
         default=os.getenv("STT_STREAMING_MODELS", "").split(),
         help="Space-separated list of STT model names that support streaming (e.g. gpt-4o-transcribe)",
     )
+    parser.add_argument(
+        "--stt-realtime-models",
+        nargs="+",
+        default=os.getenv("STT_REALTIME_MODELS", "").split(),
+        help="Space-separated list of STT model names that use Realtime transcription (e.g. gpt-realtime-whisper)",
+    )
 
     # TTS configuration
     parser.add_argument(
@@ -215,7 +221,7 @@ async def main():
 
     args = parser.parse_args()
 
-    stt_requested = bool(args.stt_models or args.stt_streaming_models)
+    stt_requested = bool(args.stt_models or args.stt_streaming_models or args.stt_realtime_models)
     tts_requested = bool(args.tts_models or args.tts_streaming_models)
     tts_validation_deferred = tts_requested and not args.tts_voices
 
@@ -266,7 +272,13 @@ async def main():
             tts_client = await exit_stack.enter_async_context(tts_client)
 
         asr_programs = (
-            create_asr_programs(args.stt_models, args.stt_streaming_models, args.stt_openai_url, args.languages)
+            create_asr_programs(
+                args.stt_models,
+                args.stt_streaming_models,
+                args.stt_openai_url,
+                args.languages,
+                stt_realtime_models=args.stt_realtime_models,
+            )
             if stt_requested
             else []
         )
@@ -374,6 +386,7 @@ async def main():
                 tts_instructions=args.tts_instructions,
                 stt_prompt=args.stt_prompt,
                 stt_extra_body=args.stt_extra_body,
+                stt_realtime_models=args.stt_realtime_models,
                 tts_extra_body=args.tts_extra_body,
                 tts_streaming_min_words=args.tts_streaming_min_words,
                 tts_streaming_max_chars=args.tts_streaming_max_chars,

--- a/src/wyoming_openai/compatibility.py
+++ b/src/wyoming_openai/compatibility.py
@@ -42,22 +42,23 @@ class TtsVoiceModel(TtsVoice):
         self.backend_voice_name = self.name if backend_voice_name is None else backend_voice_name
 
 
-def _get_ordered_unique_models(models: list[str], streaming_models: list[str]) -> list[str]:
-    """Return streaming-first model names while preserving input order."""
+def _get_ordered_unique_model_names(*model_groups: list[str]) -> list[str]:
+    """Return unique model names while preserving group and input order."""
     seen = set()
     ordered_models = []
 
-    for model_name in streaming_models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
-
-    for model_name in models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
+    for model_group in model_groups:
+        for model_name in model_group:
+            if model_name not in seen:
+                ordered_models.append(model_name)
+                seen.add(model_name)
 
     return ordered_models
+
+
+def _get_ordered_unique_models(models: list[str], streaming_models: list[str]) -> list[str]:
+    """Return streaming-first model names while preserving input order."""
+    return _get_ordered_unique_model_names(streaming_models, models)
 
 
 def _create_tts_voice_models(
@@ -104,6 +105,7 @@ def create_asr_programs(
     stt_streaming_models: list[str],
     stt_url: str,
     languages: list[str],
+    stt_realtime_models: list[str] | None = None,
 ) -> list[AsrProgram]:
     """
     Creates a list of ASR programs, separating models based on streaming support.
@@ -113,25 +115,16 @@ def create_asr_programs(
         stt_streaming_models (list[str]): List of STT models identifiers that support streaming.
         stt_url (str): The URL for the STT service attribution.
         languages (list[str]): A list of supported languages.
+        stt_realtime_models (list[str] | None): List of STT model identifiers that use Realtime transcription.
 
     Returns:
         list[AsrProgram]: A list of Wyoming ASR programs.
     """
-    # Create ordered list: streaming models first, then non-streaming, preserving natural order and deduplicating
-    seen = set()
-    ordered_models = []
+    if stt_realtime_models is None:
+        stt_realtime_models = []
 
-    # Add streaming models first
-    for model_name in stt_streaming_models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
-
-    # Add non-streaming models
-    for model_name in stt_models:
-        if model_name not in seen:
-            ordered_models.append(model_name)
-            seen.add(model_name)
+    # Create ordered list: realtime models first, then response-streaming models, then non-streaming models.
+    ordered_models = _get_ordered_unique_model_names(stt_realtime_models, stt_streaming_models, stt_models)
 
     all_asr_models = []
     for model_name in ordered_models:
@@ -146,16 +139,32 @@ def create_asr_programs(
             )
         )
 
+    realtime_asr_models = []
     streaming_asr_models = []
     non_streaming_asr_models = []
 
     for model in all_asr_models:
-        if model.name in stt_streaming_models:
+        if model.name in stt_realtime_models:
+            realtime_asr_models.append(model)
+        elif model.name in stt_streaming_models:
             streaming_asr_models.append(model)
         else:
             non_streaming_asr_models.append(model)
 
     asr_programs = []
+
+    if realtime_asr_models:
+        asr_programs.append(
+            AsrProgram(
+                name="openai-realtime",
+                description="OpenAI (Realtime)",
+                attribution=Attribution(name=ATTRIBUTION_NAME_PROGRAM_STREAMING, url=stt_url),
+                installed=True,
+                version=__version__,
+                models=realtime_asr_models,
+                supports_transcript_streaming=True,
+            )
+        )
 
     if streaming_asr_models:
         asr_programs.append(
@@ -382,7 +391,14 @@ class CustomAsyncOpenAI(AsyncOpenAI):
         if not kwargs.get("base_url"):
             kwargs["base_url"] = DEFAULT_OPENAI_BASE_URL
         self.backend: OpenAIBackend = kwargs.pop("backend", OpenAIBackend.OPENAI)
-        super().__init__(*args, **kwargs)
+        try:
+            super().__init__(*args, **kwargs)
+        except TypeError as exc:
+            if "_enforce_credentials" not in kwargs or "_enforce_credentials" not in str(exc):
+                raise
+
+            kwargs.pop("_enforce_credentials", None)
+            super().__init__(*args, **kwargs)
 
     async def _prepare_options(self, options):
         # Local keyless backends (Speaches, LocalAI, Kokoro) don't require auth.

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -353,10 +353,10 @@ class OpenAIEventHandler(AsyncEventHandler):
 
         self._is_recording = False
 
+        transcript_sent = False
         try:
             if self._realtime_transcript_future is None:
-                _LOGGER.error("Realtime transcription future was not initialized")
-                return
+                raise RealtimeTranscriptionError("Realtime transcription future was not initialized")
 
             await self._realtime_connection.input_audio_buffer.commit()
             transcript = await self._realtime_transcript_future
@@ -365,8 +365,11 @@ class OpenAIEventHandler(AsyncEventHandler):
             else:
                 _LOGGER.warning("Received empty realtime transcription result")
             await self.write_event(Transcript(text=transcript).event())
+            transcript_sent = True
         except Exception as err:
             _LOGGER.exception("Error during realtime transcription: %s", err)
+            if not transcript_sent:
+                await self.write_event(Transcript(text="").event())
         finally:
             await self.write_event(TranscriptStop().event())
             await self._cleanup_realtime_transcription()

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -396,6 +396,8 @@ class OpenAIEventHandler(AsyncEventHandler):
         transcription: dict[str, object] = {"model": self._current_asr_model.name}
         if self._current_language is not None:
             transcription["language"] = self._current_language
+        if self._stt_prompt is not None:
+            transcription["prompt"] = self._stt_prompt
 
         return {
             "type": "transcription",

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -1,9 +1,12 @@
 import asyncio
+import base64
+import contextlib
 import io
 import logging
+import struct
 import wave
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import pysbd
 from openai import AsyncStream, omit
@@ -44,6 +47,9 @@ def _truncate_for_log(text: str, max_length: int = 100) -> str:
 DEFAULT_AUDIO_WIDTH = 2  # 16-bit audio
 DEFAULT_AUDIO_CHANNELS = 1  # Mono audio
 DEFAULT_ASR_AUDIO_RATE = 16000  # Hz (Wyoming default)
+REALTIME_AUDIO_RATE = 24000  # Hz (OpenAI Realtime audio/pcm requirement)
+REALTIME_AUDIO_WIDTH = 2  # 16-bit audio
+REALTIME_AUDIO_CHANNELS = 1  # Mono audio
 TTS_AUDIO_RATE = 24000  # Hz (OpenAI spec, fallback)
 TTS_CHUNK_SIZE = 2048  # Magical guess - but must be larger than 44 bytes for a potential WAV header
 TTS_CONCURRENT_REQUESTS = 3  # Number of concurrent OpenAI TTS requests when streaming sentences
@@ -67,6 +73,10 @@ class TtsStreamError(Exception):
         self.voice = voice
 
 
+class RealtimeTranscriptionError(Exception):
+    """Raised when OpenAI Realtime transcription fails."""
+
+
 class OpenAIEventHandler(AsyncEventHandler):
     def __init__(
         self,
@@ -77,6 +87,7 @@ class OpenAIEventHandler(AsyncEventHandler):
         stt_temperature: float | None = None,
         stt_prompt: str | None = None,
         stt_extra_body: dict[str, object] | None = None,
+        stt_realtime_models: list[str] | set[str] | None = None,
         tts_speed: float | None = None,
         tts_instructions: str | None = None,
         tts_extra_body: dict[str, object] | None = None,
@@ -95,6 +106,7 @@ class OpenAIEventHandler(AsyncEventHandler):
             stt_temperature (float | None): The temperature for STT, or None for default.
             stt_prompt (str | None): An optional prompt for STT.
             stt_extra_body (dict[str, object] | None): Optional JSON body fields merged into STT requests.
+            stt_realtime_models (list[str] | set[str] | None): STT models that use OpenAI Realtime transcription.
             tts_speed (float | None): The speed for TTS, or None for default.
             tts_instructions (str | None): Optional instructions for TTS.
             tts_extra_body (dict[str, object] | None): Optional JSON body fields merged into TTS requests.
@@ -110,6 +122,7 @@ class OpenAIEventHandler(AsyncEventHandler):
         self._stt_temperature = stt_temperature
         self._stt_prompt = stt_prompt
         self._stt_extra_body = dict(stt_extra_body) if stt_extra_body else None
+        self._stt_realtime_models = set(stt_realtime_models or self._get_asr_program_model_names("openai-realtime"))
         if self._has_asr_models():
             validate_stt_extra_body(self._stt_extra_body)
 
@@ -128,6 +141,15 @@ class OpenAIEventHandler(AsyncEventHandler):
         self._is_recording: bool = False
         self._current_asr_model: AsrModel | None = None
         self._current_language: str | None = None
+        self._audio_sample_rate: int = DEFAULT_ASR_AUDIO_RATE
+        self._audio_width: int = DEFAULT_AUDIO_WIDTH
+        self._audio_channels: int = DEFAULT_AUDIO_CHANNELS
+
+        # State for realtime transcription
+        self._realtime_connection_manager: Any | None = None
+        self._realtime_connection: Any | None = None
+        self._realtime_receive_task: asyncio.Task[None] | None = None
+        self._realtime_transcript_future: asyncio.Future[str] | None = None
 
         # State for event logging
         self._last_event_type: str | None = None
@@ -200,6 +222,15 @@ class OpenAIEventHandler(AsyncEventHandler):
         _LOGGER.info("Ignoring unhandled event type: %s", event.type)
         return True
 
+    async def disconnect(self) -> None:
+        """Clean up handler-owned realtime resources when the Wyoming client disconnects."""
+        await self._cleanup_realtime_transcription()
+
+    async def stop(self) -> None:
+        """Stop the event handler without closing shared OpenAI clients."""
+        await self._cleanup_realtime_transcription()
+        await super().stop()
+
     async def _handle_transcribe(self, transcribe: Transcribe) -> bool:
         """Handle transcription request"""
         requested_model = self._get_asr_model(transcribe.name)
@@ -220,6 +251,14 @@ class OpenAIEventHandler(AsyncEventHandler):
 
     async def _handle_audio_start(self, sample_rate: int, audio_width: int, audio_channels: int) -> None:
         """Handle start of audio stream"""
+        self._audio_sample_rate = sample_rate
+        self._audio_width = audio_width
+        self._audio_channels = audio_channels
+
+        if self._current_asr_model and self._is_asr_model_realtime(self._current_asr_model.name):
+            await self._handle_realtime_audio_start(sample_rate, audio_width, audio_channels)
+            return
+
         self._is_recording = True
         self._wav_buffer = NamedBytesIO(name="recording.wav")
         self._wav_write_buffer = wave.open(self._wav_buffer, "wb")
@@ -232,13 +271,307 @@ class OpenAIEventHandler(AsyncEventHandler):
 
     async def _handle_audio_chunk(self, chunk: AudioChunk) -> None:
         """Handle audio chunk"""
+        if self._realtime_connection is not None:
+            await self._handle_realtime_audio_chunk(chunk)
+            return
+
         if self._is_recording and chunk.audio and self._wav_write_buffer:
             self._wav_write_buffer.writeframes(chunk.audio)
         else:
             _LOGGER.warning("Problem handling audio chunk")
 
+    async def _handle_realtime_audio_start(self, sample_rate: int, audio_width: int, audio_channels: int) -> None:
+        """Open an OpenAI Realtime transcription session."""
+        if not self._current_asr_model:
+            _LOGGER.warning("No ASR model set for realtime transcription")
+            return
+
+        if self._stt_client is None:
+            _LOGGER.error("No STT client configured for realtime transcription")
+            return
+
+        await self._cleanup_realtime_transcription()
+
+        self._audio_sample_rate = sample_rate
+        self._audio_width = audio_width
+        self._audio_channels = audio_channels
+
+        try:
+            self._realtime_connection_manager = self._stt_client.realtime.connect(model=self._current_asr_model.name)
+            connection = await self._enter_realtime_connection(self._realtime_connection_manager)
+            self._realtime_connection = connection
+            self._realtime_transcript_future = asyncio.get_running_loop().create_future()
+            self._realtime_receive_task = asyncio.create_task(
+                self._receive_realtime_transcription_events(), name="openai_realtime_transcription"
+            )
+
+            await connection.session.update(session=self._get_realtime_transcription_session())
+            self._is_recording = True
+            await self.write_event(TranscriptStart().event())
+            _LOGGER.info(
+                "Realtime recording started at %d Hz, %d channels, %d bytes per sample",
+                sample_rate,
+                audio_channels,
+                audio_width,
+            )
+        except Exception as err:
+            _LOGGER.exception("Error starting realtime transcription: %s", err)
+            self._is_recording = False
+            await self._cleanup_realtime_transcription()
+
+    async def _handle_realtime_audio_chunk(self, chunk: AudioChunk) -> None:
+        """Append a Wyoming audio chunk to the OpenAI Realtime input buffer."""
+        if not self._is_recording or self._realtime_connection is None:
+            _LOGGER.warning("Received realtime audio chunk without an active recording")
+            return
+
+        if not chunk.audio:
+            return
+
+        try:
+            audio = self._convert_audio_to_realtime_pcm(
+                chunk.audio,
+                sample_rate=self._audio_sample_rate,
+                audio_width=self._audio_width,
+                audio_channels=self._audio_channels,
+            )
+            if not audio:
+                return
+
+            encoded_audio = base64.b64encode(audio).decode("ascii")
+            await self._realtime_connection.input_audio_buffer.append(audio=encoded_audio)
+        except Exception as err:
+            _LOGGER.exception("Error sending realtime audio chunk: %s", err)
+            self._set_realtime_transcription_exception(err)
+
+    async def _handle_realtime_audio_stop(self) -> None:
+        """Commit realtime audio and emit the final transcription."""
+        if not self._is_recording or self._realtime_connection is None:
+            _LOGGER.warning("Received realtime audio stop event without recording")
+            await self._cleanup_realtime_transcription()
+            return
+
+        self._is_recording = False
+
+        try:
+            if self._realtime_transcript_future is None:
+                _LOGGER.error("Realtime transcription future was not initialized")
+                return
+
+            await self._realtime_connection.input_audio_buffer.commit()
+            transcript = await self._realtime_transcript_future
+            if transcript:
+                _LOGGER.info("Successfully transcribed realtime stream: %s", _truncate_for_log(transcript))
+            else:
+                _LOGGER.warning("Received empty realtime transcription result")
+            await self.write_event(Transcript(text=transcript).event())
+        except Exception as err:
+            _LOGGER.exception("Error during realtime transcription: %s", err)
+        finally:
+            await self.write_event(TranscriptStop().event())
+            await self._cleanup_realtime_transcription()
+
+    async def _enter_realtime_connection(self, connection_manager: Any) -> Any:
+        """Enter an SDK realtime connection manager."""
+        enter = getattr(connection_manager, "enter", None)
+        if enter is not None:
+            return await enter()
+
+        return await connection_manager.__aenter__()
+
+    def _get_realtime_transcription_session(self) -> dict[str, object]:
+        """Build a Realtime transcription session update payload."""
+        if not self._current_asr_model:
+            raise RealtimeTranscriptionError("No ASR model set for realtime transcription")
+
+        transcription: dict[str, object] = {"model": self._current_asr_model.name}
+        if self._current_language is not None:
+            transcription["language"] = self._current_language
+
+        return {
+            "type": "transcription",
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": REALTIME_AUDIO_RATE},
+                    "transcription": transcription,
+                    "turn_detection": None,
+                }
+            },
+        }
+
+    async def _receive_realtime_transcription_events(self) -> None:
+        """Receive Realtime server events and forward transcript deltas to Wyoming."""
+        connection = self._realtime_connection
+        transcript_future = self._realtime_transcript_future
+        if connection is None or transcript_future is None:
+            return
+
+        try:
+            async for event in connection:
+                event_type = getattr(event, "type", "")
+                if event_type == "conversation.item.input_audio_transcription.delta":
+                    delta = getattr(event, "delta", "")
+                    if delta:
+                        _LOGGER.debug("Realtime transcription chunk: %s", delta)
+                        await self.write_event(TranscriptChunk(text=delta).event())
+                elif event_type == "conversation.item.input_audio_transcription.completed":
+                    transcript = getattr(event, "transcript", "")
+                    if not transcript_future.done():
+                        transcript_future.set_result(transcript)
+                    return
+                elif event_type == "conversation.item.input_audio_transcription.failed":
+                    error = RealtimeTranscriptionError(self._get_realtime_event_error_message(event))
+                    if not transcript_future.done():
+                        transcript_future.set_exception(error)
+                    return
+                elif event_type == "error":
+                    error = RealtimeTranscriptionError(self._get_realtime_event_error_message(event))
+                    if not transcript_future.done():
+                        transcript_future.set_exception(error)
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.exception("Error receiving realtime transcription events: %s", err)
+            if not transcript_future.done():
+                transcript_future.set_exception(err)
+        else:
+            if not transcript_future.done():
+                transcript_future.set_exception(
+                    RealtimeTranscriptionError("Realtime connection closed before transcription completed")
+                )
+
+    def _get_realtime_event_error_message(self, event: Any) -> str:
+        """Extract a readable error message from a Realtime server event."""
+        error = getattr(event, "error", None)
+        if isinstance(error, dict):
+            return str(error.get("message") or error)
+
+        message = getattr(error, "message", None)
+        if message:
+            return str(message)
+
+        if error:
+            return str(error)
+
+        return f"Realtime transcription failed with event type {getattr(event, 'type', 'unknown')}"
+
+    def _set_realtime_transcription_exception(self, err: Exception) -> None:
+        """Fail the pending realtime transcription, if any."""
+        if self._realtime_transcript_future and not self._realtime_transcript_future.done():
+            self._realtime_transcript_future.set_exception(err)
+
+    async def _cleanup_realtime_transcription(self) -> None:
+        """Close the realtime connection and background receive task."""
+        receive_task = self._realtime_receive_task
+        self._realtime_receive_task = None
+        if receive_task and not receive_task.done():
+            receive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await receive_task
+
+        connection_manager = self._realtime_connection_manager
+        connection = self._realtime_connection
+        self._realtime_connection_manager = None
+        self._realtime_connection = None
+        self._realtime_transcript_future = None
+
+        if connection_manager is not None:
+            await connection_manager.__aexit__(None, None, None)
+        elif connection is not None:
+            await connection.close()
+
+    def _convert_audio_to_realtime_pcm(
+        self, audio: bytes, *, sample_rate: int, audio_width: int, audio_channels: int
+    ) -> bytes:
+        """Convert incoming Wyoming PCM to 24 kHz mono PCM16 for OpenAI Realtime."""
+        if (
+            sample_rate == REALTIME_AUDIO_RATE
+            and audio_width == REALTIME_AUDIO_WIDTH
+            and audio_channels == REALTIME_AUDIO_CHANNELS
+        ):
+            return audio
+
+        samples = self._decode_pcm_samples(audio, audio_width)
+        if not samples:
+            return b""
+
+        samples = self._downmix_pcm_samples(samples, audio_channels)
+        samples = self._resample_pcm_samples(samples, sample_rate, REALTIME_AUDIO_RATE)
+        return self._encode_pcm16_samples(samples)
+
+    def _decode_pcm_samples(self, audio: bytes, audio_width: int) -> list[int]:
+        """Decode PCM bytes into signed 16-bit sample values."""
+        sample_count = len(audio) // audio_width
+        if sample_count == 0:
+            return []
+
+        audio = audio[: sample_count * audio_width]
+        if audio_width == 1:
+            return [(sample - 128) << 8 for sample in audio]
+
+        if audio_width == 2:
+            return list(struct.unpack(f"<{sample_count}h", audio))
+
+        if audio_width == 4:
+            return [int.from_bytes(audio[i : i + 4], "little", signed=True) >> 16 for i in range(0, len(audio), 4)]
+
+        raise ValueError(f"Unsupported audio sample width for realtime transcription: {audio_width}")
+
+    def _downmix_pcm_samples(self, samples: list[int], audio_channels: int) -> list[int]:
+        """Downmix PCM samples to mono."""
+        if audio_channels <= 0:
+            raise ValueError(f"Unsupported audio channel count for realtime transcription: {audio_channels}")
+
+        if audio_channels == REALTIME_AUDIO_CHANNELS:
+            return samples
+
+        frame_count = len(samples) // audio_channels
+        mono_samples = []
+        for frame_index in range(frame_count):
+            start = frame_index * audio_channels
+            mono_samples.append(round(sum(samples[start : start + audio_channels]) / audio_channels))
+        return mono_samples
+
+    def _resample_pcm_samples(self, samples: list[int], source_rate: int, target_rate: int) -> list[int]:
+        """Linearly resample PCM samples to the target sample rate."""
+        if source_rate <= 0:
+            raise ValueError(f"Unsupported audio sample rate for realtime transcription: {source_rate}")
+
+        if source_rate == target_rate or len(samples) < 2:
+            return samples
+
+        output_count = max(1, round(len(samples) * target_rate / source_rate))
+        resampled = []
+        for output_index in range(output_count):
+            source_position = output_index * source_rate / target_rate
+            left_index = int(source_position)
+            if left_index >= len(samples) - 1:
+                resampled.append(samples[-1])
+                continue
+
+            fraction = source_position - left_index
+            sample = samples[left_index] + (samples[left_index + 1] - samples[left_index]) * fraction
+            resampled.append(round(sample))
+
+        return resampled
+
+    def _encode_pcm16_samples(self, samples: list[int]) -> bytes:
+        """Encode signed sample values as little-endian PCM16."""
+        if not samples:
+            return b""
+
+        clamped_samples = (max(-32768, min(32767, int(sample))) for sample in samples)
+        return struct.pack(f"<{len(samples)}h", *clamped_samples)
+
     async def _handle_audio_stop(self) -> None:
         """Handle end of audio stream and perform transcription"""
+        if self._realtime_connection is not None or (
+            self._current_asr_model and self._is_asr_model_realtime(self._current_asr_model.name)
+        ):
+            await self._handle_realtime_audio_stop()
+            return
+
         if not self._is_recording or not self._wav_buffer:
             _LOGGER.warning("Received audio stop event without recording")
             return
@@ -335,6 +668,15 @@ class OpenAIEventHandler(AsyncEventHandler):
                     return model
         return None
 
+    def _get_asr_program_model_names(self, program_name: str) -> set[str]:
+        """Return ASR model names advertised by a specific program."""
+        return {
+            model.name
+            for program in self._wyoming_info.asr
+            if getattr(program, "name", None) == program_name
+            for model in program.models
+        }
+
     def _has_asr_models(self) -> bool:
         """Return True when STT is configured for this handler."""
         return any(getattr(program, "models", None) for program in self._wyoming_info.asr)
@@ -374,6 +716,10 @@ class OpenAIEventHandler(AsyncEventHandler):
                 if model.name == model_name:
                     return program.supports_transcript_streaming
         return False
+
+    def _is_asr_model_realtime(self, model_name: str) -> bool:
+        """Check if an ASR model should use OpenAI Realtime transcription."""
+        return model_name in self._stt_realtime_models
 
     def _is_tts_voice_streaming(self, voice_name: str) -> bool:
         """Check if a TTS voice supports streaming synthesis"""

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -297,7 +297,7 @@ class OpenAIEventHandler(AsyncEventHandler):
         self._audio_channels = audio_channels
 
         try:
-            self._realtime_connection_manager = self._stt_client.realtime.connect(model=self._current_asr_model.name)
+            self._realtime_connection_manager = self._connect_realtime_transcription()
             connection = await self._enter_realtime_connection(self._realtime_connection_manager)
             self._realtime_connection = connection
             self._realtime_transcript_future = asyncio.get_running_loop().create_future()
@@ -378,6 +378,12 @@ class OpenAIEventHandler(AsyncEventHandler):
             return await enter()
 
         return await connection_manager.__aenter__()
+
+    def _connect_realtime_transcription(self) -> Any:
+        """Create a Realtime transcription-session websocket connection manager."""
+        if self._stt_client is None:
+            raise RealtimeTranscriptionError("No STT client configured for realtime transcription")
+        return self._stt_client.realtime.connect(extra_query={"intent": "transcription"})
 
     def _get_realtime_transcription_session(self) -> dict[str, object]:
         """Build a Realtime transcription session update payload."""

--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -292,10 +292,6 @@ class OpenAIEventHandler(AsyncEventHandler):
 
         await self._cleanup_realtime_transcription()
 
-        self._audio_sample_rate = sample_rate
-        self._audio_width = audio_width
-        self._audio_channels = audio_channels
-
         try:
             self._realtime_connection_manager = self._connect_realtime_transcription()
             connection = await self._enter_realtime_connection(self._realtime_connection_manager)
@@ -481,11 +477,15 @@ class OpenAIEventHandler(AsyncEventHandler):
             with contextlib.suppress(asyncio.CancelledError):
                 await receive_task
 
+        transcript_future = self._realtime_transcript_future
+        self._realtime_transcript_future = None
+        if transcript_future is not None and not transcript_future.done():
+            transcript_future.cancel()
+
         connection_manager = self._realtime_connection_manager
         connection = self._realtime_connection
         self._realtime_connection_manager = None
         self._realtime_connection = None
-        self._realtime_transcript_future = None
 
         if connection_manager is not None:
             await connection_manager.__aexit__(None, None, None)

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -387,6 +387,36 @@ class TestHelperFunctions:
         programs = create_asr_programs([], [], "https://api.openai.com", ["en"])
         assert programs == []
 
+    def test_create_asr_programs_with_realtime_models(self):
+        """Test creating ASR programs with realtime transcription models."""
+        programs = create_asr_programs(
+            ["whisper-1"],
+            ["gpt-4o-transcribe"],
+            "https://api.openai.com",
+            ["en"],
+            stt_realtime_models=["gpt-realtime-whisper"],
+        )
+
+        assert [program.name for program in programs] == ["openai-realtime", "openai-streaming", "openai"]
+
+        realtime_prog = programs[0]
+        assert realtime_prog.supports_transcript_streaming is True
+        assert [model.name for model in realtime_prog.models] == ["gpt-realtime-whisper"]
+
+    def test_create_asr_programs_prefers_realtime_transport_for_duplicate_model(self):
+        """Test duplicate ASR model names are classified as realtime first."""
+        programs = create_asr_programs(
+            ["gpt-realtime-whisper"],
+            ["gpt-realtime-whisper"],
+            "https://api.openai.com",
+            ["en"],
+            stt_realtime_models=["gpt-realtime-whisper"],
+        )
+
+        assert len(programs) == 1
+        assert programs[0].name == "openai-realtime"
+        assert [model.name for model in programs[0].models] == ["gpt-realtime-whisper"]
+
     def test_create_tts_voices_detailed(self):
         """Test creating TTS voices with multiple models and voices."""
         models = ["tts-1", "tts-1-hd"]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -755,11 +755,9 @@ class TestOpenAIEventHandlerComprehensive:
         session = connection.session.update.call_args.kwargs["session"]
         assert session["type"] == "transcription"
         assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
-        assert session["audio"]["input"]["transcription"] == {
-            "model": "gpt-realtime-whisper",
-            "language": "en",
-            "prompt": "Test prompt",
-        }
+        transcription = session["audio"]["input"]["transcription"]
+        assert transcription["model"] == "gpt-realtime-whisper"
+        assert transcription["language"] == "en"
         assert session["audio"]["input"]["turn_detection"] is None
         assert base64.b64decode(connection.input_audio_buffer.appended_audio[0]) == audio_data
         assert connection.input_audio_buffer.committed is True
@@ -851,17 +849,17 @@ class TestOpenAIEventHandlerComprehensive:
     @pytest.mark.asyncio
     async def test_realtime_transcription_session_includes_configured_prompt(self, enhanced_handler, mock_info):
         """Test realtime STT preserves configured prompt in the session payload."""
-        mock_info.asr[0].models[0].name = "gpt-realtime-whisper"
-        enhanced_handler._stt_realtime_models = {"gpt-realtime-whisper"}
+        mock_info.asr[0].models[0].name = "gpt-4o-transcribe"
+        enhanced_handler._stt_realtime_models = {"gpt-4o-transcribe"}
 
         assert await enhanced_handler.handle_event(
-            Event(type="transcribe", data={"language": "en", "name": "gpt-realtime-whisper"})
+            Event(type="transcribe", data={"language": "en", "name": "gpt-4o-transcribe"})
         )
 
         session = enhanced_handler._get_realtime_transcription_session()
 
         assert session["audio"]["input"]["transcription"] == {
-            "model": "gpt-realtime-whisper",
+            "model": "gpt-4o-transcribe",
             "language": "en",
             "prompt": "Test prompt",
         }

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -755,7 +755,11 @@ class TestOpenAIEventHandlerComprehensive:
         session = connection.session.update.call_args.kwargs["session"]
         assert session["type"] == "transcription"
         assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
-        assert session["audio"]["input"]["transcription"] == {"model": "gpt-realtime-whisper", "language": "en"}
+        assert session["audio"]["input"]["transcription"] == {
+            "model": "gpt-realtime-whisper",
+            "language": "en",
+            "prompt": "Test prompt",
+        }
         assert session["audio"]["input"]["turn_detection"] is None
         assert base64.b64decode(connection.input_audio_buffer.appended_audio[0]) == audio_data
         assert connection.input_audio_buffer.committed is True
@@ -843,6 +847,24 @@ class TestOpenAIEventHandlerComprehensive:
         )
 
         assert len(converted) == 6
+
+    @pytest.mark.asyncio
+    async def test_realtime_transcription_session_includes_configured_prompt(self, enhanced_handler, mock_info):
+        """Test realtime STT preserves configured prompt in the session payload."""
+        mock_info.asr[0].models[0].name = "gpt-realtime-whisper"
+        enhanced_handler._stt_realtime_models = {"gpt-realtime-whisper"}
+
+        assert await enhanced_handler.handle_event(
+            Event(type="transcribe", data={"language": "en", "name": "gpt-realtime-whisper"})
+        )
+
+        session = enhanced_handler._get_realtime_transcription_session()
+
+        assert session["audio"]["input"]["transcription"] == {
+            "model": "gpt-realtime-whisper",
+            "language": "en",
+            "prompt": "Test prompt",
+        }
 
     @pytest.mark.asyncio
     async def test_handle_transcribe_preserves_configured_speaches_vad_filter(self, enhanced_handler, mock_clients):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -778,7 +778,7 @@ class TestOpenAIEventHandlerComprehensive:
 
     @pytest.mark.asyncio
     async def test_handle_realtime_transcription_error_cleans_up(self, enhanced_handler, mock_info, mock_clients):
-        """Test realtime STT errors emit TranscriptStop and clean up the websocket task."""
+        """Test realtime STT errors emit final Transcript and clean up the websocket task."""
         stt_client, _ = mock_clients
         mock_info.asr[0].models[0].name = "gpt-realtime-whisper"
         enhanced_handler._stt_realtime_models = {"gpt-realtime-whisper"}
@@ -806,10 +806,33 @@ class TestOpenAIEventHandlerComprehensive:
         stt_client.realtime.connect.assert_called_once_with(extra_query={"intent": "transcription"})
         stt_client.audio.transcriptions.create.assert_not_called()
         event_types = [call.args[0].type for call in enhanced_handler.write_event.call_args_list]
-        assert event_types == ["transcript-start", "transcript-stop"]
+        assert event_types == ["transcript-start", "transcript", "transcript-stop"]
+        transcript_event = next(
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "transcript"
+        )
+        assert Transcript.from_event(transcript_event).text == ""
         assert manager.exited is True
         assert connection.closed is True
         assert enhanced_handler._realtime_receive_task is None
+
+    @pytest.mark.asyncio
+    async def test_handle_realtime_audio_stop_missing_future_emits_final_transcript(self, enhanced_handler):
+        """Test realtime STT stop emits final Transcript when future state is missing."""
+        connection = Mock()
+        connection.input_audio_buffer.commit = AsyncMock()
+        connection.close = AsyncMock()
+        enhanced_handler._is_recording = True
+        enhanced_handler._realtime_connection = connection
+        enhanced_handler._realtime_transcript_future = None
+        enhanced_handler.write_event = AsyncMock()
+
+        await enhanced_handler._handle_realtime_audio_stop()
+
+        event_types = [call.args[0].type for call in enhanced_handler.write_event.call_args_list]
+        assert event_types == ["transcript", "transcript-stop"]
+        transcript_event = enhanced_handler.write_event.call_args_list[0].args[0]
+        assert Transcript.from_event(transcript_event).text == ""
+        connection.input_audio_buffer.commit.assert_not_called()
 
     def test_convert_audio_to_realtime_pcm_resamples_to_24khz(self, enhanced_handler):
         """Test Wyoming PCM is converted to OpenAI Realtime's 24 kHz PCM16 format."""

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -749,7 +749,7 @@ class TestOpenAIEventHandlerComprehensive:
         )
         await enhanced_handler.handle_event(Event(type="audio-stop"))
 
-        stt_client.realtime.connect.assert_called_once_with(model="gpt-realtime-whisper")
+        stt_client.realtime.connect.assert_called_once_with(extra_query={"intent": "transcription"})
         stt_client.audio.transcriptions.create.assert_not_called()
         connection.session.update.assert_called_once()
         session = connection.session.update.call_args.kwargs["session"]
@@ -803,6 +803,7 @@ class TestOpenAIEventHandlerComprehensive:
         )
         await enhanced_handler.handle_event(Event(type="audio-stop"))
 
+        stt_client.realtime.connect.assert_called_once_with(extra_query={"intent": "transcription"})
         stt_client.audio.transcriptions.create.assert_not_called()
         event_types = [call.args[0].type for call in enhanced_handler.write_event.call_args_list]
         assert event_types == ["transcript-start", "transcript-stop"]

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,3 +1,5 @@
+import asyncio
+import base64
 import builtins
 import io
 import wave
@@ -5,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from openai import omit
-from wyoming.asr import Transcript
+from wyoming.asr import Transcript, TranscriptChunk
 from wyoming.event import Event
 from wyoming.info import Attribution, TtsVoice
 from wyoming.tts import SynthesizeChunk, SynthesizeStart, SynthesizeVoice
@@ -73,6 +75,68 @@ def handler(dummy_info, dummy_clients, dummy_reader_writer):
         stt_client=stt_client,
         tts_client=tts_client,
     )
+
+
+class _FakeRealtimeServerEvent:
+    def __init__(self, event_type, **kwargs):
+        self.type = event_type
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _FakeRealtimeSession:
+    def __init__(self):
+        self.update = AsyncMock()
+
+
+class _FakeRealtimeInputAudioBuffer:
+    def __init__(self, connection):
+        self._connection = connection
+        self.appended_audio = []
+        self.committed = False
+
+    async def append(self, *, audio):
+        self.appended_audio.append(audio)
+
+    async def commit(self):
+        self.committed = True
+        for event in self._connection.commit_events:
+            await self._connection.events.put(event)
+
+
+class _FakeRealtimeConnection:
+    def __init__(self, commit_events):
+        self.commit_events = commit_events
+        self.events = asyncio.Queue()
+        self.session = _FakeRealtimeSession()
+        self.input_audio_buffer = _FakeRealtimeInputAudioBuffer(self)
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        event = await self.events.get()
+        if event is None:
+            raise StopAsyncIteration
+        return event
+
+    async def close(self):
+        self.closed = True
+        await self.events.put(None)
+
+
+class _FakeRealtimeConnectionManager:
+    def __init__(self, connection):
+        self.connection = connection
+        self.exited = False
+
+    async def enter(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
+        await self.connection.close()
 
 
 @pytest.mark.asyncio
@@ -655,6 +719,106 @@ class TestOpenAIEventHandlerComprehensive:
                 assert transcript.text == "Test transcription"
                 break
         assert transcript_found
+
+    @pytest.mark.asyncio
+    async def test_handle_realtime_transcription_flow(self, enhanced_handler, mock_info, mock_clients):
+        """Test realtime STT emits deltas, final transcript, and cleanup without audio transcriptions API."""
+        stt_client, _ = mock_clients
+        mock_info.asr[0].models[0].name = "gpt-realtime-whisper"
+        enhanced_handler._stt_realtime_models = {"gpt-realtime-whisper"}
+
+        connection = _FakeRealtimeConnection(
+            [
+                _FakeRealtimeServerEvent("conversation.item.input_audio_transcription.delta", delta="Hello"),
+                _FakeRealtimeServerEvent(
+                    "conversation.item.input_audio_transcription.completed", transcript="Hello world"
+                ),
+            ]
+        )
+        manager = _FakeRealtimeConnectionManager(connection)
+        stt_client.realtime.connect = Mock(return_value=manager)
+        stt_client.audio.transcriptions.create = AsyncMock()
+
+        transcribe_event = Event(type="transcribe", data={"language": "en", "name": "gpt-realtime-whisper"})
+        assert await enhanced_handler.handle_event(transcribe_event) is True
+
+        audio_data = b"\x00\x01" * 100
+        await enhanced_handler.handle_event(Event(type="audio-start", data={"rate": 24000, "width": 2, "channels": 1}))
+        await enhanced_handler.handle_event(
+            Event(type="audio-chunk", data={"rate": 24000, "width": 2, "channels": 1}, payload=audio_data)
+        )
+        await enhanced_handler.handle_event(Event(type="audio-stop"))
+
+        stt_client.realtime.connect.assert_called_once_with(model="gpt-realtime-whisper")
+        stt_client.audio.transcriptions.create.assert_not_called()
+        connection.session.update.assert_called_once()
+        session = connection.session.update.call_args.kwargs["session"]
+        assert session["type"] == "transcription"
+        assert session["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+        assert session["audio"]["input"]["transcription"] == {"model": "gpt-realtime-whisper", "language": "en"}
+        assert session["audio"]["input"]["turn_detection"] is None
+        assert base64.b64decode(connection.input_audio_buffer.appended_audio[0]) == audio_data
+        assert connection.input_audio_buffer.committed is True
+
+        event_types = [call.args[0].type for call in enhanced_handler.write_event.call_args_list]
+        assert event_types == ["transcript-start", "transcript-chunk", "transcript", "transcript-stop"]
+        chunk_event = next(
+            call.args[0]
+            for call in enhanced_handler.write_event.call_args_list
+            if call.args[0].type == "transcript-chunk"
+        )
+        assert TranscriptChunk.from_event(chunk_event).text == "Hello"
+        transcript_event = next(
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "transcript"
+        )
+        assert Transcript.from_event(transcript_event).text == "Hello world"
+        assert manager.exited is True
+        assert connection.closed is True
+        assert enhanced_handler._realtime_receive_task is None
+
+    @pytest.mark.asyncio
+    async def test_handle_realtime_transcription_error_cleans_up(self, enhanced_handler, mock_info, mock_clients):
+        """Test realtime STT errors emit TranscriptStop and clean up the websocket task."""
+        stt_client, _ = mock_clients
+        mock_info.asr[0].models[0].name = "gpt-realtime-whisper"
+        enhanced_handler._stt_realtime_models = {"gpt-realtime-whisper"}
+
+        connection = _FakeRealtimeConnection(
+            [
+                _FakeRealtimeServerEvent(
+                    "conversation.item.input_audio_transcription.failed", error={"message": "bad audio"}
+                )
+            ]
+        )
+        manager = _FakeRealtimeConnectionManager(connection)
+        stt_client.realtime.connect = Mock(return_value=manager)
+        stt_client.audio.transcriptions.create = AsyncMock()
+
+        assert await enhanced_handler.handle_event(
+            Event(type="transcribe", data={"language": "en", "name": "gpt-realtime-whisper"})
+        )
+        await enhanced_handler.handle_event(Event(type="audio-start", data={"rate": 24000, "width": 2, "channels": 1}))
+        await enhanced_handler.handle_event(
+            Event(type="audio-chunk", data={"rate": 24000, "width": 2, "channels": 1}, payload=b"\x00\x01" * 10)
+        )
+        await enhanced_handler.handle_event(Event(type="audio-stop"))
+
+        stt_client.audio.transcriptions.create.assert_not_called()
+        event_types = [call.args[0].type for call in enhanced_handler.write_event.call_args_list]
+        assert event_types == ["transcript-start", "transcript-stop"]
+        assert manager.exited is True
+        assert connection.closed is True
+        assert enhanced_handler._realtime_receive_task is None
+
+    def test_convert_audio_to_realtime_pcm_resamples_to_24khz(self, enhanced_handler):
+        """Test Wyoming PCM is converted to OpenAI Realtime's 24 kHz PCM16 format."""
+        source_audio = b"\x00\x00\xe8\x03"
+
+        converted = enhanced_handler._convert_audio_to_realtime_pcm(
+            source_audio, sample_rate=16000, audio_width=2, audio_channels=1
+        )
+
+        assert len(converted) == 6
 
     @pytest.mark.asyncio
     async def test_handle_transcribe_preserves_configured_speaches_vad_filter(self, enhanced_handler, mock_clients):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -260,7 +260,7 @@ async def test_main_allows_unused_stt_response_format_in_tts_only_mode(monkeypat
     async def fake_factory(*args, **kwargs):
         return _FakeClient()
 
-    for env_var in ("STT_MODELS", "STT_STREAMING_MODELS"):
+    for env_var in ("STT_MODELS", "STT_STREAMING_MODELS", "STT_REALTIME_MODELS"):
         monkeypatch.delenv(env_var, raising=False)
 
     monkeypatch.setattr(
@@ -348,7 +348,7 @@ async def test_main_skips_stt_client_creation_in_tts_only_mode(monkeypatch):
         "from_uri",
         staticmethod(lambda uri: server),
     )
-    for env_var in ("STT_MODELS", "STT_STREAMING_MODELS"):
+    for env_var in ("STT_MODELS", "STT_STREAMING_MODELS", "STT_REALTIME_MODELS"):
         monkeypatch.delenv(env_var, raising=False)
     monkeypatch.setattr(
         sys,
@@ -368,3 +368,41 @@ async def test_main_skips_stt_client_creation_in_tts_only_mode(monkeypatch):
     assert len(server.handlers) == 1
     assert server.handlers[0]._stt_client is None
     assert server.handlers[0]._tts_client is not None
+
+
+@pytest.mark.asyncio
+async def test_main_configures_realtime_stt_models(monkeypatch):
+    server = _CapturingServer()
+
+    async def fake_factory(*args, **kwargs):
+        return _FakeClient()
+
+    monkeypatch.setattr(
+        main_module.CustomAsyncOpenAI,
+        "create_autodetected_factory",
+        staticmethod(lambda: fake_factory),
+    )
+    monkeypatch.setattr(
+        main_module.AsyncServer,
+        "from_uri",
+        staticmethod(lambda uri: server),
+    )
+    for env_var in ("TTS_MODELS", "TTS_STREAMING_MODELS", "TTS_VOICES"):
+        monkeypatch.delenv(env_var, raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "wyoming_openai",
+            "--stt-realtime-models",
+            "gpt-realtime-whisper",
+        ],
+    )
+
+    await main()
+
+    assert len(server.handlers) == 1
+    handler = server.handlers[0]
+    assert handler._stt_client is not None
+    assert handler._tts_client is None
+    assert handler._stt_realtime_models == {"gpt-realtime-whisper"}


### PR DESCRIPTION
## Summary
Implements #59: adds OpenAI Realtime transcription as a new STT transport for Wyoming ASR, alongside the existing `/v1/audio/transcriptions` and response-streaming paths.

- New `--stt-realtime-models` / `STT_REALTIME_MODELS` config selects models that open a `/v1/realtime` transcription session over WebSocket. The handler picks transport from this config rather than from hard-coded model name checks.
- Realtime models are advertised as a separate `openai-realtime` ASR program with `supports_transcript_streaming=True`.
- Connection uses `extra_query={"intent": "transcription"}` and sets the model inside the `session.update` transcription block, so any transcription-capable model (`whisper-1`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-realtime-whisper`) works — not just `gpt-realtime-whisper`.
- Incoming Wyoming PCM is converted to 24 kHz mono PCM16, base64-encoded, and appended via `input_audio_buffer.append`; Wyoming `AudioStop` triggers `input_audio_buffer.commit`. A background receive task forwards `conversation.item.input_audio_transcription.delta` events as Wyoming `TranscriptChunk` and the `.completed` event as the final `Transcript`.
- `--stt-prompt` / `STT_PROMPT` is forwarded into the realtime transcription session when set.
- On realtime errors (`.failed`, `error`, connection-closed-early), always emit a final empty `Transcript` before `TranscriptStop` so Wyoming clients' state machines complete instead of hanging on `TranscriptStart`.
- Dependency bumped to `openai[realtime]==2.37.0` so the `websockets` dep that `client.realtime.connect()` imports lazily is available.
- README documents the new option, lists realtime-capable model names, explains how `STT_STREAMING_MODELS` vs `STT_REALTIME_MODELS` map to different OpenAI endpoints, and drops the now-implemented "OpenAI Realtime API" item from the Future Plans section.

## Test plan
- [x] `pytest` — covers CLI parsing, info/program construction, realtime handler flow (deltas + completion), error and cleanup paths (including WebSocket/background task teardown), and prompt forwarding
- [x] `ruff check .`
- [x] Manually verified end-to-end with Home Assistant against an OpenAI Realtime transcription session

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
