### PR TITLE
Add compatibility/contributing docs, issue templates, normalize URLs

### DIFF
--- a/.agents/skills/community-triage/SKILL.md
+++ b/.agents/skills/community-triage/SKILL.md
@@ -143,6 +143,7 @@ If the issue remains unsupported by evidence after reasonable follow-up, close i
 - Do not treat "it works in another server's `/tts` route" as evidence that this repo should adopt that route.
 - Do not add speculative compatibility code for transports that are not part of the supported contract.
 - Do not widen the compatibility layer beyond small, clearly bounded backend exceptions without explicit maintainer intent.
+- Do not add new provider-specific autodetection probes (custom `/health`, `/readyz`, `/test`, or similar routes) when explicit backend configuration or the OpenAI-compatible surface itself can identify the backend. A new provider-specific route is justifiable only when it fills a gap the OpenAI spec does not cover (for example voice listing); pure identity probes do not meet that bar.
 - Prefer "upstream should make their OpenAI-compatible surface behave correctly" over "this proxy should learn every custom dialect."
 
 ## Boundary Example
@@ -282,6 +283,7 @@ Reopen or continue when:
 - conflating "streaming exists somewhere in the upstream project" with "the supported integration surface streams here"
 - adding fallback behavior for undocumented responses
 - treating backend enum exceptions as permission for general vendor lock-in
+- adding new provider-specific autodetection probes when explicit backend configuration would work. Provider-specific routes are acceptable only when they fill a gap the OpenAI spec lacks (for example voice/model listing) — not for pure identity probes.
 
 ## Maintainer Intent Distilled
 

--- a/.agents/skills/community-triage/SKILL.md
+++ b/.agents/skills/community-triage/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: community-triage
+description: GitHub issues, pull requests, bug reports, scope questions, and support threads. Use when handling community reports or PRs to separate supported OpenAI-compatible behavior from out-of-scope provider-specific requests, request missing evidence, route upstream, and close or escalate politely.
+---
+
+# Community Triage
+
+Handle community issues and PRs with respect, evidence, and firm scope discipline.
+
+This skill exists to protect maintainer time, avoid speculative changes, and preserve the project's intended boundary.
+
+## Project Boundary
+
+- Wyoming OpenAI is an OpenAI-compatible proxy/middleware.
+- Treat OpenAI-compatible request/response behavior as the primary contract.
+- Existing backend enum/autodetection exceptions are compatibility shims, not a license to support arbitrary provider-specific transports, routes, or schemas.
+- Do not expand scope to custom endpoints such as `/tts`, provider-specific `stream=true` semantics, or bespoke response formats unless the maintainer explicitly chooses to widen scope.
+
+## Goals
+
+- Be helpful without overcommitting.
+- Separate local defects from upstream limitations and unsupported integrations.
+- Prefer minimal actionable next steps: fix locally, request reproduction details, route upstream, or close with clear reasoning.
+- Maintain a respectful tone even when issue quality is low.
+
+## Default Posture
+
+- Assume good faith.
+- Do not mirror vague or incorrect technical framing.
+- Translate the report into the actual technical question the project can answer.
+- Use evidence from code, tests, docs, and upstream behavior before concluding.
+- Do not let conversation momentum expand the project's scope by accident.
+
+## Triage Workflow
+
+1. Classify the thread.
+2. Identify the supported surface.
+3. Gather evidence.
+4. Decide ownership.
+5. Respond with a clear outcome.
+
+### 1. Classify the thread
+
+Choose the closest category:
+
+- bug/regression on a supported surface
+- feature request inside scope
+- feature request outside scope
+- support question or configuration issue
+- upstream compatibility issue
+- low-fidelity report with insufficient reproduction
+- community PR
+
+### 2. Identify the supported surface
+
+Pin down the exact surface before deciding anything:
+
+- endpoint path
+- Wyoming event flow
+- CLI/config flag
+- backend compatibility path
+- testable request/response behavior
+
+Explicitly determine whether the report concerns an OpenAI-compatible path or instead depends on a custom provider API.
+
+### 3. Gather evidence
+
+Use the repo and upstream references, not assumptions.
+
+- inspect the relevant implementation and tests in this repo
+- read linked upstream docs/issues/PRs, not just their titles or summaries
+- verify the exact route, request schema, and response transport involved
+- distinguish between "supports streaming somewhere" and "streams on the exact supported integration surface used here"
+
+### 4. Decide ownership
+
+Assign the issue to one bucket:
+
+- local defect in this repo
+- upstream defect or limitation
+- out-of-scope custom integration request
+- uncertain because key evidence is still missing
+
+### 5. Respond with a clear outcome
+
+Pick one outcome and be explicit:
+
+- implement/fix
+- ask for concrete reproduction details
+- route upstream
+- close politely with scope reasoning
+
+## Evidence Standard
+
+Treat these as strong evidence:
+
+- code paths
+- tests
+- official docs
+- concrete reproductions
+- exact request/response behavior
+- linked upstream implementation details
+
+Treat these as weak evidence:
+
+- issue titles
+- second-hand descriptions
+- marketing claims
+- "OpenAI-compatible" labels without route-level confirmation
+- "supports streaming" claims without transport details
+
+Do not conclude a behavior is supported just because a provider advertises compatibility. Confirm the specific surface this project actually uses.
+
+## Minimum Missing Details To Request
+
+When the report is ambiguous, ask for only what is necessary to decide ownership.
+
+Good examples:
+
+- exact endpoint path
+- sample request/response behavior
+- provider or server project link
+- version or commit
+- relevant logs
+- minimal reproduction steps
+
+Do not start by asking for everything. Ask for the smallest missing fact that would change the decision.
+
+## Low-Fidelity Issues
+
+When a report is vague, technically confused, or incomplete:
+
+- extract the likely underlying question
+- ask at most a small number of precise follow-ups
+- request only the missing details needed to decide whether this repo owns the problem
+- avoid speculative fixes or speculative roadmap commitments
+
+If the issue remains unsupported by evidence after reasonable follow-up, close it politely rather than leaving it open indefinitely.
+
+## Scope Guardrails
+
+- Do not add support for provider-specific custom endpoints when an OpenAI-compatible endpoint already exists but behaves differently.
+- Do not treat "it works in another server's `/tts` route" as evidence that this repo should adopt that route.
+- Do not add speculative compatibility code for transports that are not part of the supported contract.
+- Do not widen the compatibility layer beyond small, clearly bounded backend exceptions without explicit maintainer intent.
+- Prefer "upstream should make their OpenAI-compatible surface behave correctly" over "this proxy should learn every custom dialect."
+
+## Boundary Example
+
+If an upstream Chatterbox server streams on a custom `/tts` endpoint but buffers on its OpenAI-compatible `/v1/audio/speech` endpoint:
+
+- do not add `/tts` support here
+- do not reopen scope just because the custom route exists
+- explain that Wyoming OpenAI targets the OpenAI-compatible surface
+- route streaming complaints about `/v1/audio/speech` upstream unless there is evidence this repo mishandles a truly incremental OpenAI-compatible response
+
+## Issue Decision Matrix
+
+### Keep Open Or Fix Here
+
+Keep the issue open or fix it when:
+
+- there is evidence the failure occurs on a supported OpenAI-compatible surface used by this repo
+- the behavior regressed from prior repo behavior
+- a minimal fix exists without expanding scope
+- the report includes enough detail to reproduce or the code clearly shows a defect
+
+### Ask For Details
+
+Ask for more detail when:
+
+- the failure might be in this repo, but one or two key facts are missing
+- the report mixes supported and unsupported surfaces and needs disambiguation
+- an upstream implementation claims compatibility but the actual route/response behavior is still unknown
+
+### Route Upstream
+
+Route upstream when:
+
+- the failing behavior lives in another project's OpenAI-compatible server or provider
+- the linked implementation buffers where true streaming is expected
+- the only path that provides the requested capability is a custom upstream endpoint outside this repo's target contract
+
+### Close
+
+Close when:
+
+- the request depends on a custom provider-specific API outside project scope
+- there is no evidence of a defect in this repo after reasonable triage
+- the issue asks for a nonexistent or irrelevant API surface
+- the request would materially expand scope or maintenance burden beyond the maintainer's intent
+
+## PR Review Guidance
+
+Review community PRs primarily for:
+
+- scope fit
+- correctness
+- maintenance cost
+- tests on supported behavior
+- regression risk
+
+Be especially skeptical of PRs that:
+
+- add provider-specific routes or bespoke schemas
+- teach the proxy custom behavior for one server in a way that weakens the OpenAI-compatible boundary
+- include broad refactors alongside compatibility changes
+- add fallback code without evidence of a real supported use case
+
+Prefer minimal changes that keep the contract clear.
+
+If a PR changes supported behavior, ask for tests.
+
+If asked to review a PR, present findings first with file/line references. If the PR's main value is widening scope to cover a custom upstream dialect, recommend narrowing or closing the PR instead of merging it.
+
+## Response Style
+
+- Thank the reporter or contributor for concrete links, repros, or code references.
+- Be direct and factual.
+- Avoid blame, sarcasm, or dismissal.
+- Avoid phrases like "you don't know what you're talking about" even if the original framing is wrong.
+
+Prefer phrasing such as:
+
+- "I do not currently see evidence that the limitation is in this project."
+- "This appears to be upstream of Wyoming OpenAI."
+- "That endpoint is outside the OpenAI-compatible surface this project targets."
+- "If you can show this failing on `/v1/audio/speech`, that would be worth revisiting."
+
+Avoid phrasing such as:
+
+- "Not my problem."
+- "Works for me."
+- speculative roadmap commitments
+- over-apologizing for enforcing scope
+
+## Closure Pattern
+
+When closing, include all of the following:
+
+- what was checked
+- why the issue is out of scope or upstream
+- the specific supported surface this project targets
+- the condition under which the issue would become actionable here
+
+Template:
+
+> Thanks for the report and the additional reference.
+>
+> I checked the relevant code path and the linked implementation. Wyoming OpenAI already supports [supported behavior] on its OpenAI-compatible path, and I do not currently see evidence of a defect in this project.
+>
+> The behavior you are pointing to depends on [custom endpoint / upstream server behavior], which is outside the OpenAI-compatible surface this project targets.
+>
+> If there is evidence of the same problem on [exact supported surface], feel free to share reproduction details and it can be revisited.
+
+## Upstream Escalation Pattern
+
+When routing upstream:
+
+- name the exact upstream repo, issue, or route
+- describe the boundary cleanly
+- do not volunteer to mirror custom APIs locally
+
+Template:
+
+> This looks like an upstream compatibility issue rather than a Wyoming OpenAI bug.
+>
+> The key question is whether [upstream project] behaves correctly on its OpenAI-compatible [route]. If that surface is buffered or otherwise diverges from OpenAI behavior, the fix belongs there rather than in this proxy.
+
+## Re-entry Criteria
+
+Reopen or continue when:
+
+- a reporter provides a concrete reproduction on a supported OpenAI-compatible surface
+- a community PR narrows itself to supported behavior and includes tests
+- upstream changes make the supported surface behave differently and this repo needs a bounded compatibility adjustment
+
+## Anti-Patterns
+
+- implementing custom provider transports to salvage one wrapper
+- keeping vague issues open indefinitely
+- conflating "streaming exists somewhere in the upstream project" with "the supported integration surface streams here"
+- adding fallback behavior for undocumented responses
+- treating backend enum exceptions as permission for general vendor lock-in
+
+## Maintainer Intent Distilled
+
+- Be kind to community contributors.
+- Keep the contract narrow.
+- Favor evidence over momentum.
+- Push upstream when the real defect lives upstream.
+- Close unsupported or low-fidelity issues cleanly so maintainers are not left carrying indefinite support debt.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Report a reproducible bug on a supported surface.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report.
+
+        Before filing, please confirm this is about a supported OpenAI-compatible surface or core Wyoming behavior. Questions and setup help belong in Discussions.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      description: Pick the closest supported surface involved.
+      options:
+        - OpenAI-compatible /v1/audio/transcriptions
+        - OpenAI-compatible /v1/audio/speech
+        - OpenAI Realtime /v1/realtime transcription
+        - Wyoming event flow or handler behavior
+        - CLI or configuration behavior
+        - Documentation
+        - Other or not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Wyoming OpenAI version
+      description: PyPI version, Docker tag, or commit SHA.
+      placeholder: 0.5.0
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: Provider or upstream server
+      description: Name the provider, wrapper, or server project involved.
+      placeholder: OpenAI, Speaches, LocalAI, Chatterbox-TTS-Server
+    validations:
+      required: true
+  - type: input
+    id: upstream_link
+    attributes:
+      label: Upstream project or issue link
+      description: Link the upstream server or issue if another project is involved.
+      placeholder: https://github.com/example/project
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Exact steps, requests, or configuration needed to reproduce the issue.
+      placeholder: |
+        1. Start Wyoming OpenAI with ...
+        2. Send request to ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or config snippets
+      description: Include only the relevant portion and remove secrets.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: I have removed secrets from logs and config snippets.
+          required: true
+        - label: This report is about a supported OpenAI-compatible or core Wyoming surface, or I clearly linked the upstream project involved.
+          required: true

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,0 +1,73 @@
+name: Compatibility report
+description: Report an interoperability problem with an OpenAI-compatible provider or wrapper.
+title: "[Compatibility]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when another provider or wrapper claims OpenAI compatibility but does not appear to behave correctly on the route Wyoming OpenAI uses.
+
+        If the behavior only exists on a custom provider route such as `/tts`, it is likely upstream or out of scope here.
+  - type: input
+    id: project
+    attributes:
+      label: Upstream project or provider
+      placeholder: Chatterbox-TTS-Server
+    validations:
+      required: true
+  - type: input
+    id: project_link
+    attributes:
+      label: Upstream project link
+      placeholder: https://github.com/example/project
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Upstream version or commit
+      placeholder: v1.2.3 or abc1234
+  - type: dropdown
+    id: route
+    attributes:
+      label: Exact route involved
+      options:
+        - OpenAI-compatible /v1/audio/transcriptions
+        - OpenAI-compatible /v1/audio/speech
+        - OpenAI Realtime /v1/realtime transcription
+        - A custom provider route
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: divergence
+    attributes:
+      label: How does the behavior diverge?
+      description: Describe the specific request or response behavior that differs from the supported OpenAI-compatible surface.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Include enough detail to show whether the problem belongs here or upstream.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link exact docs, code, logs, or upstream issues.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I linked the upstream project or implementation involved.
+          required: true
+        - label: I am reporting behavior on the OpenAI-compatible route used by Wyoming OpenAI, or I clearly explained why I am unsure.
+          required: true
+        - label: I understand that support for custom provider routes may be out of scope.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and support
+    url: https://github.com/roryeckel/wyoming_openai/discussions
+    about: Use Discussions for setup help, usage questions, and general support.
+  - name: Scope and compatibility policy
+    url: https://github.com/roryeckel/wyoming_openai/blob/main/COMPATIBILITY.md
+    about: Read this before filing issues about provider compatibility or custom APIs.
+  - name: Contribution guide
+    url: https://github.com/roryeckel/wyoming_openai/blob/main/CONTRIBUTING.md
+    about: Review project scope, issue expectations, and PR guidelines.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a scoped feature request for Wyoming OpenAI.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+
+        This project prioritizes OpenAI-compatible behavior. Requests that mainly depend on provider-specific custom APIs are unlikely to be accepted here.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user problem first, not just the proposed solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the behavior you want to see.
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface would this affect?
+      options:
+        - OpenAI-compatible /v1/audio/transcriptions
+        - OpenAI-compatible /v1/audio/speech
+        - OpenAI Realtime /v1/realtime transcription
+        - Wyoming event flow or handler behavior
+        - CLI or configuration behavior
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or upstream context
+      description: Include upstream links, related projects, or alternatives you considered.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: I understand this project primarily targets OpenAI-compatible behavior.
+          required: true
+        - label: This request is not solely asking for support of a provider-specific custom API outside the OpenAI-compatible surface.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,13 @@ reads cleanly out of context.
 
 
 
+## Checklist
+
+- [ ] This change stays within the project's supported scope.
+- [ ] Tests were added or updated if supported behavior changed.
+- [ ] Docs were updated if user-facing behavior changed.
+- [ ] This does not add a provider-specific custom API without prior maintainer approval.
+
 ## Details
 
 <!-- Optional: implementation notes, design choices, links to related issues/PRs. Closes #N goes here. -->
@@ -21,5 +28,4 @@ reads cleanly out of context.
 ## Testing
 
 <!-- How you verified this. Commands run, manual steps, screenshots, etc. -->
-
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -33,6 +33,31 @@ This project includes a small backend compatibility layer for some known backend
 
 These shims exist to smooth known interoperability gaps. They are not a general policy of implementing every provider-specific route or dialect.
 
+### Provider-Specific Helpers: Allowed Carve-Outs
+
+The OpenAI API spec does not cover every operation this proxy needs. A small set of provider-specific routes are accepted as carve-outs, but **only** when they fill a gap the OpenAI spec does not provide.
+
+Allowed carve-outs today:
+
+| Helper | Route | Why accepted |
+| --- | --- | --- |
+| `_list_kokoro_fastapi_voices` | `/audio/voices` | OpenAI has no voice-listing endpoint. |
+| `_list_speaches_voices` | `/models/{model}` and legacy `/audio/speech/voices` | OpenAI has no per-model voice-listing endpoint. |
+| `_list_localai_voices` | none (synthesizes voice from model name) | Fills the same voice-listing gap without a custom route. |
+
+The rule: a provider-specific route is acceptable when it provides a capability the OpenAI-compatible surface lacks (for example, listing available voices or models). It is not acceptable when an OpenAI-compatible route already provides the capability.
+
+### Backend Autodetection
+
+Backend autodetection currently relies on provider-specific health endpoints (for example `/test`, `/readyz`, and `/health`) for the historical backends above. Unlike the voice-listing carve-outs, these probes do not fill a gap in the OpenAI spec — they only identify which shim to apply.
+
+Adding new custom-route health probes is discouraged. Prefer, in order:
+
+1. explicit `--stt-backend` / `--tts-backend` configuration, or
+2. detection via the OpenAI-compatible surface itself.
+
+A new provider-specific route is justifiable only when it provides a capability the OpenAI-compatible surface lacks (see the voice-listing carve-outs above); pure identity probes do not meet that bar.
+
 ## Out of Scope by Default
 
 The following are out of scope unless explicitly approved by the maintainer:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,94 @@
+# Compatibility and Scope
+
+This document explains what compatibility means in Wyoming OpenAI.
+
+## Primary Contract
+
+Wyoming OpenAI is an OpenAI-compatible proxy for the Wyoming protocol.
+
+The primary contract is the OpenAI-compatible surface exposed by upstream providers or wrappers, not every custom API those projects may also offer.
+
+## Supported Surfaces
+
+These are the core surfaces this project intentionally targets.
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| OpenAI-compatible `/v1/audio/transcriptions` | Supported | Includes standard transcription handling and response-streaming support for configured models. |
+| OpenAI-compatible `/v1/audio/speech` | Supported | Includes provider-side audio byte streaming when the backend actually returns incremental bytes. |
+| OpenAI Realtime transcription via `/v1/realtime` | Supported | Used for configured realtime STT models. |
+| Wyoming `synthesize-start/chunk/stop` input flow | Supported | Wyoming-side incremental text input is supported, while still targeting OpenAI-compatible TTS upstream. |
+| Wyoming transcription and synthesis event handling | Supported | Core project behavior. |
+
+## Limited Backend Shims
+
+This project includes a small backend compatibility layer for some known backends.
+
+| Backend enum | Status | Notes |
+| --- | --- | --- |
+| `OPENAI` | First-class | Official OpenAI-compatible behavior. |
+| `SPEACHES` | Limited shim | Small compatibility helpers such as backend detection and voice/model handling. |
+| `KOKORO_FASTAPI` | Limited shim | Small compatibility helpers such as backend detection and voice discovery. |
+| `LOCALAI` | Limited shim | Small compatibility helpers such as backend detection and voice handling. |
+
+These shims exist to smooth known interoperability gaps. They are not a general policy of implementing every provider-specific route or dialect.
+
+## Out of Scope by Default
+
+The following are out of scope unless explicitly approved by the maintainer:
+
+- provider-specific custom routes such as `/tts`
+- provider-specific `stream=true` semantics outside the OpenAI-compatible surface
+- custom request or response schemas for a single wrapper project
+- bespoke streaming event formats or transports that are not part of the supported OpenAI-compatible contract
+
+## How Wrapper Compatibility Is Evaluated
+
+Projects often describe themselves as OpenAI-compatible. That label alone is not enough.
+
+Compatibility is evaluated on the actual behavior of the route this project uses.
+
+Questions that matter:
+
+- Does the wrapper implement the OpenAI-compatible route used here?
+- Does it accept the expected request schema?
+- Does it return the expected response format?
+- If streaming is claimed, does it stream on the OpenAI-compatible route or only on a custom route?
+
+Example:
+
+- If a wrapper streams on a custom `/tts` endpoint but buffers on its OpenAI-compatible `/v1/audio/speech` endpoint, Wyoming OpenAI will still treat the custom `/tts` route as out of scope.
+
+## Community-Reported Compatibility
+
+Some providers, wrappers, and deployment guides may work in practice without being explicitly tested in CI.
+
+That usually means:
+
+- they appear compatible on the OpenAI-compatible surface
+- they may be covered by docs or examples
+- they are not guaranteed to support every advanced feature or every future version
+
+Community-reported compatibility is not the same thing as a commitment to support provider-specific custom APIs.
+
+## When To File an Issue Here
+
+File an issue here when:
+
+- the failing behavior is on a supported OpenAI-compatible surface
+- you can show a reproduction or concrete evidence
+- this repo appears to mishandle that supported behavior
+
+## When To File Upstream
+
+File upstream when:
+
+- the failure exists only on a custom provider route
+- the upstream OpenAI-compatible route buffers, diverges, or otherwise does not behave like the surface this project expects
+- the wrapper only provides the requested capability through a non-OpenAI-compatible endpoint
+
+## Related Docs
+
+- [README.md](README.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- GitHub Discussions for support and setup questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ The following are usually out of scope unless explicitly approved by the maintai
 - provider-specific streaming flags or transport semantics outside the OpenAI-compatible surface
 - custom request or response schemas for a single upstream wrapper
 - speculative compatibility code without a concrete supported use case
+- new provider-specific health-check or autodetection endpoints (such as custom `/health`, `/readyz`, or `/test` routes) when explicit backend configuration or the OpenAI-compatible surface itself can identify the backend
+
+The one accepted exception to "no provider-specific routes" is a helper that fills a gap the OpenAI spec does not cover — for example, listing available voices, which OpenAI has no endpoint for. A provider-specific route is justifiable only when it provides a capability the OpenAI-compatible surface lacks. Pure identity or health probes do not meet that bar.
 
 If an upstream project exposes both an OpenAI-compatible route and a custom route, this project targets the OpenAI-compatible route.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,171 @@
+# Contributing to Wyoming OpenAI
+
+Thanks for contributing.
+
+This project is an OpenAI-compatible proxy for the Wyoming protocol. Contributions are most useful when they keep that contract clear, stay small, and come with enough evidence to show where a problem belongs.
+
+## Scope
+
+Wyoming OpenAI targets OpenAI-compatible request and response behavior.
+
+That means contributions are generally in scope when they improve or fix:
+
+- OpenAI-compatible `/v1/audio/transcriptions`
+- OpenAI-compatible `/v1/audio/speech`
+- OpenAI Realtime transcription sessions used through `/v1/realtime`
+- Wyoming protocol handling and event flow
+- configuration, docs, tests, and packaging around those surfaces
+
+This project also includes a small backend compatibility layer for known backends such as `SPEACHES`, `KOKORO_FASTAPI`, and `LOCALAI`.
+
+Those backend shims are limited compatibility conveniences. They are not a general policy of supporting arbitrary provider-specific APIs.
+
+## Out of Scope
+
+The following are usually out of scope unless explicitly approved by the maintainer first:
+
+- provider-specific custom endpoints such as `/tts`
+- provider-specific streaming flags or transport semantics outside the OpenAI-compatible surface
+- custom request or response schemas for a single upstream wrapper
+- speculative compatibility code without a concrete supported use case
+
+If an upstream project exposes both an OpenAI-compatible route and a custom route, this project targets the OpenAI-compatible route.
+
+For more detail, see [COMPATIBILITY.md](COMPATIBILITY.md).
+
+## Before Opening an Issue
+
+Please first:
+
+- search existing issues and discussions
+- confirm the exact endpoint or behavior involved
+- gather a minimal reproduction if possible
+- check whether the issue is on an OpenAI-compatible surface or on a custom provider API
+
+Use GitHub Discussions for:
+
+- setup help
+- backend questions
+- "is this supported?"
+- general usage questions
+
+Use GitHub Issues for:
+
+- reproducible bugs
+- well-scoped feature requests
+- documentation errors
+- compatibility reports on the supported OpenAI-compatible surface
+
+## Good Bug Reports
+
+The most helpful bug reports include:
+
+- exact version or commit
+- provider or upstream server name and version
+- exact endpoint or behavior involved
+- minimal reproduction steps
+- expected behavior
+- actual behavior
+- relevant logs or configuration snippets
+- links to upstream issues if the behavior may come from another project
+
+When a report depends on another server or wrapper, include a link to that project and the exact route being used.
+
+## Good Feature Requests
+
+Good feature requests:
+
+- explain the user problem first
+- stay within the project's supported OpenAI-compatible boundary
+- explain why existing behavior is insufficient
+- avoid asking this project to learn a custom API from another provider or wrapper
+
+If the request depends on a provider-specific custom route, it is unlikely to be accepted here.
+
+## Pull Requests
+
+### Keep changes narrow
+
+Prefer the smallest correct change.
+
+- one concern per PR
+- avoid unrelated refactors
+- avoid adding fallback behavior for undocumented responses
+- do not expand scope to custom provider APIs without prior maintainer approval
+
+### Add or update tests when behavior changes
+
+If you change supported behavior, add or update tests.
+
+### Update docs when user-facing behavior changes
+
+If the CLI, compatibility story, or visible behavior changes, update the relevant docs.
+
+### Preserve boundaries
+
+PRs that mainly add support for one provider's custom route, schema, or transport are likely to be declined even if the code works.
+
+## Development Setup
+
+Install development dependencies:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+Run linting:
+
+```bash
+ruff check .
+pyright
+```
+
+Useful targeted commands:
+
+```bash
+pytest tests/test_handler.py
+ruff check . --fix
+```
+
+## Naming and URL Conventions
+
+Different surfaces use different name forms, each matching the form its platform renders as canonical.
+
+- **GitHub (underscore: `wyoming_openai`)** — canonical repository URL is `https://github.com/roryeckel/wyoming_openai`. Use the underscore form for all GitHub web links, `git clone` URLs, and badge URLs (image src and href).
+- **PyPI (hyphen: `wyoming-openai`)** — PyPI normalizes the project name and renders it with a hyphen on `https://pypi.org/project/wyoming-openai/`. Use the hyphen form for PyPI URLs and `pip install` commands. Both `pip install wyoming-openai` and `pip install wyoming_openai` work.
+- **Python package, module, and Docker image (underscore: `wyoming_openai`)** — the importable module (`python -m wyoming_openai`), the `pyproject.toml` project name, and the published Docker image (`ghcr.io/roryeckel/wyoming_openai`) all use the underscore form.
+
+## Review Expectations
+
+Community PRs are reviewed primarily for:
+
+- correctness
+- scope fit
+- maintenance cost
+- regression risk
+- test coverage on supported behavior
+
+Even correct code may be declined if it expands the project's scope beyond OpenAI-compatible behavior.
+
+## Upstream vs Local Issues
+
+Not every compatibility problem belongs in this repo.
+
+If another project advertises OpenAI compatibility but diverges on the actual behavior of `/v1/audio/speech`, `/v1/audio/transcriptions`, or `/v1/realtime`, the fix may belong upstream.
+
+In general:
+
+- if the problem is on the supported OpenAI-compatible surface and this repo mishandles it, open an issue here
+- if the problem exists only on a custom upstream route or wrapper-specific transport, raise it upstream instead
+
+## Tone
+
+Please be direct, factual, and respectful.
+
+Community issues and PRs are welcome, but maintaining a narrow, predictable contract is a project goal, not a rejection of contributors.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 OpenAI-Compatible Proxy Middleware for the Wyoming Protocol
 
-[![License](https://img.shields.io/github/license/roryeckel/wyoming-openai.svg)](https://github.com/roryeckel/wyoming-openai/blob/main/LICENSE) [![Python version](https://img.shields.io/pypi/pyversions/wyoming-openai.svg)](https://pypi.org/project/wyoming-openai/) [![GitHub issues](https://img.shields.io/github/issues/roryeckel/wyoming-openai.svg)](https://github.com/roryeckel/wyoming-openai/issues) [![Docker](https://img.shields.io/github/v/release/roryeckel/wyoming-openai?label=ghcr.io&logo=docker&logoColor=white&color=2496ED)](https://github.com/roryeckel/wyoming-openai/pkgs/container/wyoming_openai) [![PyPI version](https://badge.fury.io/py/wyoming-openai.svg)](https://pypi.org/project/wyoming-openai/)
+[![License](https://img.shields.io/github/license/roryeckel/wyoming_openai.svg)](https://github.com/roryeckel/wyoming_openai/blob/main/LICENSE) [![Python version](https://img.shields.io/pypi/pyversions/wyoming-openai.svg)](https://pypi.org/project/wyoming-openai/) [![GitHub issues](https://img.shields.io/github/issues/roryeckel/wyoming_openai.svg)](https://github.com/roryeckel/wyoming_openai/issues) [![Docker](https://img.shields.io/github/v/release/roryeckel/wyoming_openai?label=ghcr.io&logo=docker&logoColor=white&color=2496ED)](https://github.com/roryeckel/wyoming_openai/pkgs/container/wyoming_openai) [![PyPI version](https://badge.fury.io/py/wyoming-openai.svg)](https://pypi.org/project/wyoming-openai/)
 
 **Author:** Rory Eckel
 
 Note: This project is not affiliated with OpenAI or the Wyoming project.
+
+## Scope and Community Support
+
+Wyoming OpenAI primarily targets OpenAI-compatible APIs and the Wyoming protocol event flows built around them.
+
+- Questions, setup help, and general support: use [GitHub Discussions](https://github.com/roryeckel/wyoming_openai/discussions)
+- Bug reports, compatibility reports, and scoped feature requests: use [GitHub Issues](https://github.com/roryeckel/wyoming_openai/issues)
+- Project scope and compatibility policy: see [COMPATIBILITY.md](COMPATIBILITY.md)
+- Contribution expectations: see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+Provider-specific custom endpoints and bespoke transports are generally out of scope unless explicitly approved. If another project exposes both an OpenAI-compatible route and a custom route, Wyoming OpenAI targets the OpenAI-compatible route.
 
 ## Overview
 
@@ -53,8 +64,8 @@ Example: Sharing TTS/STT services between [Open WebUI](#open-webui) and [Home As
 1. **Clone the Repository**
 
    ```bash
-   git clone https://github.com/roryeckel/wyoming-openai.git
-   cd wyoming-openai
+   git clone https://github.com/roryeckel/wyoming_openai.git
+   cd wyoming_openai
    ```
 
 2. **Create a Virtual Environment** (optional but recommended)
@@ -95,7 +106,7 @@ To enable symlink support on Windows:
 1. Enable **Developer Mode** in Windows Settings (Settings → System → For developers)
 2. Either clone with symlinks enabled:
    ```bash
-   git clone -c core.symlinks=true https://github.com/roryeckel/wyoming-openai.git
+   git clone -c core.symlinks=true https://github.com/roryeckel/wyoming_openai.git
    ```
    Or, if you've already cloned, enable symlinks and re-checkout:
    ```bash
@@ -106,7 +117,7 @@ To enable symlink support on Windows:
 
 You can verify symlinks are working by checking that `CLAUDE.md` contains the full project instructions rather than just the text `AGENTS.md`.
 
-## Installation from PyPI [![Publish to PyPI](https://github.com/roryeckel/wyoming-openai/actions/workflows/publish-to-pypi.yml/badge.svg)](https://github.com/roryeckel/wyoming-openai/actions/workflows/publish-to-pypi.yml)
+## Installation from PyPI [![Publish to PyPI](https://github.com/roryeckel/wyoming_openai/actions/workflows/publish-to-pypi.yml/badge.svg)](https://github.com/roryeckel/wyoming_openai/actions/workflows/publish-to-pypi.yml)
 
 Since v0.3.2, `wyoming-openai` is now available on [PyPI](https://pypi.org/project/wyoming-openai/). To install the latest release, run:
 
@@ -186,7 +197,7 @@ In addition to using command-line arguments, you can configure the Wyoming OpenA
 
 Both `STT_EXTRA_BODY` and `TTS_EXTRA_BODY` must be valid JSON objects. The OpenAI client merges these values into the outgoing request body rather than sending a nested `extra_body` field. Supported overlaps still need to match Wyoming's transport expectations: STT continues to require `response_format="json"`, and a boolean `stream` override will update both the request body and the client's response parser for `/v1/audio/transcriptions`. TTS can override raw-audio fields such as `response_format`, `speed`, and `instructions`, but rejects `stream` and `stream_format` because the handler expects audio bytes instead of SSE-style framing.
 
-## Docker (Recommended) [![Docker Image CI](https://github.com/roryeckel/wyoming-openai/actions/workflows/docker-image.yml/badge.svg)](https://github.com/roryeckel/wyoming-openai/actions/workflows/docker-image.yml)
+## Docker (Recommended) [![Docker Image CI](https://github.com/roryeckel/wyoming_openai/actions/workflows/docker-image.yml/badge.svg)](https://github.com/roryeckel/wyoming_openai/actions/workflows/docker-image.yml)
 
 ### Prerequisites
 
@@ -531,7 +542,7 @@ Contributions are welcome! Please feel free to open issues or submit pull reques
 
 ## Quality Assurance
 
-### Linting (Ruff) [![Lint](https://github.com/roryeckel/wyoming-openai/actions/workflows/lint.yml/badge.svg)](https://github.com/roryeckel/wyoming-openai/actions/workflows/lint.yml)
+### Linting (Ruff) [![Lint](https://github.com/roryeckel/wyoming_openai/actions/workflows/lint.yml/badge.svg)](https://github.com/roryeckel/wyoming_openai/actions/workflows/lint.yml)
 
 This project uses [Ruff](https://github.com/astral-sh/ruff) for linting and code quality checks. Ruff is a fast Python linter written in Rust that can replace multiple tools like flake8, isort, and more.
 
@@ -567,7 +578,7 @@ To use Pyright during development:
 
 Pyright configuration is defined in `pyproject.toml` under `[tool.pyright]`.
 
-### Testing (Pytest) [![Test](https://github.com/roryeckel/wyoming-openai/actions/workflows/test.yml/badge.svg)](https://github.com/roryeckel/wyoming-openai/actions/workflows/test.yml)
+### Testing (Pytest) [![Test](https://github.com/roryeckel/wyoming_openai/actions/workflows/test.yml/badge.svg)](https://github.com/roryeckel/wyoming_openai/actions/workflows/test.yml)
 
 This project uses [pytest](https://pytest.org/) for unit testing. Tests are located in the [`tests/`](tests/) directory and cover core modules such as compatibility, constants, handlers, initialization, and utilities.
 


### PR DESCRIPTION
## Summary

Documentation and repository metadata changes only — no source code modified.

- Add `COMPATIBILITY.md` documenting supported OpenAI-compatible surfaces, backend shims, and provider-specific helper carve-outs (including the policy on backend autodetection via health probes vs. explicit `--stt-backend`/`--tts-backend` configuration)
- Add `CONTRIBUTING.md` with naming/URL conventions (underscore for GitHub/Docker/Python module, hyphen for PyPI), scope, and review expectations
- Add GitHub issue templates: bug report, feature request, compatibility report
- Add `config.yml` with `blank_issues_enabled: false` to route users to templates
- Add community-triage skill for handling community reports/PRs
- Normalize GitHub URLs in README and PR template to the canonical underscore form (`roryeckel/wyoming_openai`)
- Extend PR template with a scope/checklist section

## Checklist

- [x] This change stays within the project's supported scope.
- [x] Tests were added or updated if supported behavior changed.
- [x] Docs were updated if user-facing behavior changed.
- [x] This does not add a provider-specific custom API without prior maintainer approval.

## Details

Docs-only PR. No source code or behavior changes.

- `blank_issues_enabled: false` is a deliberate policy choice to route reports through templates — please confirm this is intended.
- Backend enum and supported-surface claims in `COMPATIBILITY.md` were verified against `compatibility.py` and the handler/CLI code.
- The provider-specific carve-out table (`_list_kokoro_fastapi_voices`, `_list_speaches_voices`, `_list_localai_voices`) and the autodetection policy section were cross-checked against current code in `compatibility.py`.

## Testing

- `pytest` — no source changes, suite unaffected
- `ruff check .` — clean
- `pyright` — clean
- Manually reviewed every URL/badge in README for correct underscore form