### PR TITLE
Add Soniqo Speech Core deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,46 @@ For users who want to use Groq's fast inference cloud API, this setup provides a
   docker compose -f docker-compose.groq.yml up -d
   ```
 
-#### 9. Development with Docker
+#### 9. Deploying with Soniqo Speech Core
+
+[Soniqo Speech Core](https://github.com/soniqo/speech-core) provides local
+OpenAI-compatible speech-to-text and text-to-speech on Linux and Windows. Its
+server uses Parakeet for transcription and Kokoro for synthesis, with no audio
+or text sent to a remote service.
+
+Install a Speech Core release that exposes both `/v1/audio/transcriptions` and
+`/v1/audio/speech`, download its model bundle, and create a `.env` file with a
+shared key:
+
+```dotenv
+SPEECH_SERVER_API_KEY=replace-with-a-random-value
+```
+
+Start Speech Core on the host so the Wyoming container can reach it:
+
+```bash
+SPEECH_SERVER_API_KEY=replace-with-a-random-value \
+  speech serve --host 0.0.0.0
+```
+
+On Windows, run the server from the extracted package's `bin` directory:
+
+```powershell
+$env:SPEECH_SERVER_API_KEY = 'replace-with-a-random-value'
+.\speech-server.exe --host 0.0.0.0
+```
+
+Then start the included bridge config:
+
+```bash
+docker compose -f docker-compose.soniqo.yml up -d
+```
+
+The compose file advertises `whisper-1`, `tts-1`, and the bundled Kokoro voice
+IDs to Home Assistant. `host.docker.internal` works with Docker Desktop, and
+the included `host-gateway` mapping provides the same hostname on Linux.
+
+#### 10. Development with Docker
 
 If you are developing the Wyoming OpenAI proxy server and want to build it from source, use the `docker-compose.dev.yml` file along with the base configuration.
 
@@ -365,9 +404,9 @@ If you are developing the Wyoming OpenAI proxy server and want to build it from 
   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
   ```
 
-#### 10. Example: Development with Additional Local Service
+#### 11. Example: Development with Additional Local Service
 
-For a development setup using the Speaches local service, combine `docker-compose.speaches.yml` and `docker-compose.dev.yml`. This also works for `docker-compose.kokoro-fastapi.yml`, `docker-compose.localai.yml`, `docker-compose.voxtral.yml`, `docker-compose.openai-edge-tts.yml`, `docker-compose.groq.yml`, and `docker-compose.chatterbox.yml`.
+For a development setup using the Speaches local service, combine `docker-compose.speaches.yml` and `docker-compose.dev.yml`. This also works for `docker-compose.kokoro-fastapi.yml`, `docker-compose.localai.yml`, `docker-compose.voxtral.yml`, `docker-compose.openai-edge-tts.yml`, `docker-compose.groq.yml`, `docker-compose.soniqo.yml`, and `docker-compose.chatterbox.yml`.
 
 - **Command**:
   
@@ -375,7 +414,7 @@ For a development setup using the Speaches local service, combine `docker-compos
   docker compose -f docker-compose.speaches.yml -f docker-compose.dev.yml up -d --build
   ```
 
-#### 11. Docker Tags
+#### 12. Docker Tags
 
 We follow specific tagging conventions for our Docker images. These tags help in identifying the version and branch of the code that a particular Docker image is based on.
 
@@ -389,7 +428,7 @@ We follow specific tagging conventions for our Docker images. These tags help in
 
 - **`pr-{number}`**: Pull request tags (e.g., `pr-123`) are automatically created for each pull request to allow testing of proposed changes before they are merged. These tags are automatically cleaned up when the pull request is closed or merged.
 
-#### 12. Pull Request Docker Images
+#### 13. Pull Request Docker Images
 
 For contributors and maintainers who want to test changes from pull requests before they are merged, we automatically build and push Docker images for each pull request.
 

--- a/docker-compose.soniqo.yml
+++ b/docker-compose.soniqo.yml
@@ -1,0 +1,25 @@
+services:
+  wyoming_openai:
+    image: ghcr.io/roryeckel/wyoming_openai:latest
+    container_name: wyoming_openai
+    ports:
+      - "10300:10300"
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      WYOMING_URI: tcp://0.0.0.0:10300
+      WYOMING_LOG_LEVEL: INFO
+      WYOMING_LANGUAGES: en
+      STT_OPENAI_URL: http://host.docker.internal:8080/v1
+      STT_OPENAI_KEY: ${SPEECH_SERVER_API_KEY}
+      STT_MODELS: "whisper-1"
+      STT_BACKEND: "OPENAI"
+      TTS_OPENAI_URL: http://host.docker.internal:8080/v1
+      TTS_OPENAI_KEY: ${SPEECH_SERVER_API_KEY}
+      TTS_MODELS: "tts-1"
+      TTS_VOICES: "alloy af_bella af_heart af_nicole af_sky am_adam am_michael bf_emma bm_george"
+      TTS_BACKEND: "OPENAI"
+      TTS_SPEED: "1.0"
+    env_file:
+      - .env


### PR DESCRIPTION
## Why

Soniqo Speech Core exposes local OpenAI-compatible transcription and speech synthesis on Linux and Windows. This configuration lets Home Assistant use those models through the existing Wyoming bridge without a second model server or cloud audio path.

The transcription half depends on [soniqo/speech-core#118](https://github.com/soniqo/speech-core/pull/118).

## What changed

- add `docker-compose.soniqo.yml` for the host-native Speech Core server
- configure `whisper-1`, `tts-1`, bundled Kokoro voices, and a shared bearer token
- map `host.docker.internal` through `host-gateway` for Linux as well as Docker Desktop
- document Linux and Windows startup plus Home Assistant usage

## Data flow

```text
Home Assistant -> Wyoming :10300 -> Speech Core :8080
                  WAV STT <-|-> WAV TTS
```

## Validation

- parsed `docker-compose.soniqo.yml` with Ruby YAML
- ran `docker compose config --quiet` with a test key
- ran `git diff --check`

The default remains unchanged; this is an opt-in deployment file.