### PR TITLE
Honor WAV data chunk boundaries

### DIFF
--- a/src/wyoming_openai/handler.py
+++ b/src/wyoming_openai/handler.py
@@ -1476,14 +1476,23 @@ class OpenAIEventHandler(AsyncEventHandler):
             # Try to parse WAV header
             wav_params = self._parse_wav_header(audio_data)
             if wav_params:
-                audio_rate, audio_channels, audio_width, data_offset = wav_params
-                audio_data = audio_data[data_offset:]
+                audio_rate, audio_channels, audio_width, data_offset, data_size = wav_params
+                available_audio = audio_data[data_offset:]
+                if len(available_audio) < data_size:
+                    _LOGGER.warning(
+                        "TTS WAV response ended after %d of %d declared PCM bytes",
+                        len(available_audio),
+                        data_size,
+                    )
+                audio_data = available_audio[:data_size]
                 _LOGGER.debug(
-                    "Detected audio format: %d Hz, %d channels, %d bytes/sample, header offset: %d",
+                    "Detected audio format: %d Hz, %d channels, %d bytes/sample, "
+                    "header offset: %d, PCM size: %d bytes",
                     audio_rate,
                     audio_channels,
                     audio_width,
                     data_offset,
+                    data_size,
                 )
             else:
                 _LOGGER.debug("Could not parse WAV header, using defaults: %d Hz", TTS_AUDIO_RATE)
@@ -1559,6 +1568,7 @@ class OpenAIEventHandler(AsyncEventHandler):
             timestamp = start_timestamp
             awaiting_wav_header = self._get_tts_response_format() == "wav"
             pending_header = b""
+            remaining_wav_data: int | None = None
 
             if self._tts_client is None:
                 _LOGGER.error("No TTS client configured for synthesis")
@@ -1582,16 +1592,20 @@ class OpenAIEventHandler(AsyncEventHandler):
                             pending_header += chunk
                             wav_params = self._parse_wav_header(pending_header)
                             if wav_params:
-                                audio_rate, audio_channels, audio_width, data_offset = wav_params
-                                audio_data = pending_header[data_offset:]
+                                audio_rate, audio_channels, audio_width, data_offset, data_size = wav_params
+                                available_audio = pending_header[data_offset:]
+                                audio_data = available_audio[:data_size]
+                                remaining_wav_data = data_size - len(audio_data)
                                 pending_header = b""
                                 awaiting_wav_header = False
                                 _LOGGER.debug(
-                                    "Detected audio format: %d Hz, %d channels, %d bytes/sample, header offset: %d",
+                                    "Detected audio format: %d Hz, %d channels, %d bytes/sample, "
+                                    "header offset: %d, PCM size: %d bytes",
                                     audio_rate,
                                     audio_channels,
                                     audio_width,
                                     data_offset,
+                                    data_size,
                                 )
                             elif len(pending_header) <= TTS_WAV_HEADER_MAX_BYTES:
                                 continue
@@ -1605,6 +1619,9 @@ class OpenAIEventHandler(AsyncEventHandler):
                                 awaiting_wav_header = False
                         else:
                             audio_data = chunk
+                            if remaining_wav_data is not None:
+                                audio_data = audio_data[:remaining_wav_data]
+                                remaining_wav_data -= len(audio_data)
 
                         if send_audio_start:
                             await self.write_event(
@@ -1630,6 +1647,12 @@ class OpenAIEventHandler(AsyncEventHandler):
                                 audio_width=audio_width,
                                 audio_channels=audio_channels,
                             )
+
+            if remaining_wav_data:
+                _LOGGER.warning(
+                    "TTS WAV response ended with %d declared PCM bytes missing",
+                    remaining_wav_data,
+                )
 
             if awaiting_wav_header and pending_header:
                 _LOGGER.warning(
@@ -1680,10 +1703,10 @@ class OpenAIEventHandler(AsyncEventHandler):
         actual_frames = len(audio_data) // frame_size
         return timestamp + (actual_frames / audio_rate) * 1000
 
-    def _parse_wav_header(self, wav_data: bytes) -> tuple[int, int, int, int] | None:
+    def _parse_wav_header(self, wav_data: bytes) -> tuple[int, int, int, int, int] | None:
         """
-        Parse WAV header to extract sample rate, channels, sample width, and data offset.
-        Returns (sample_rate, channels, sample_width, data_offset) or None if parsing fails.
+        Parse WAV header to extract the PCM format, data offset, and data size.
+        Returns (sample_rate, channels, sample_width, data_offset, data_size) or None if parsing fails.
         """
         try:
             # Create a BytesIO object from the data
@@ -1694,11 +1717,12 @@ class OpenAIEventHandler(AsyncEventHandler):
                 sample_rate = wav_file.getframerate()
                 channels = wav_file.getnchannels()
                 sample_width = wav_file.getsampwidth()
+                data_size = wav_file.getnframes() * channels * sample_width
 
                 # Get the current position which should be at the start of audio data
                 data_offset = wav_io.tell()
 
-                return sample_rate, channels, sample_width, data_offset
+                return sample_rate, channels, sample_width, data_offset, data_size
         except Exception as e:
             _LOGGER.debug("Failed to parse WAV header: %s", e)
             return None

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import builtins
 import io
+import struct
 import wave
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -17,6 +18,27 @@ from wyoming_openai.handler import (
     OpenAIEventHandler,
     TtsStreamError,
 )
+
+
+def _riff_chunk(chunk_id: bytes, payload: bytes) -> bytes:
+    """Build a word-aligned RIFF chunk."""
+    padding = b"\x00" if len(payload) % 2 else b""
+    return chunk_id + struct.pack("<I", len(payload)) + payload + padding
+
+
+def _pcm_wav_with_trailing_metadata(pcm: bytes) -> bytes:
+    """Build a valid PCM WAV with LIST/INFO and C2PA chunks after data."""
+    wav_buffer = io.BytesIO()
+    with wave.open(wav_buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(24000)
+        wav_file.writeframes(pcm)
+
+    wav_data = wav_buffer.getvalue()
+    metadata = _riff_chunk(b"LIST", b"INFOISFT\x08\x00\x00\x00CrispASR") + _riff_chunk(b"C2PA", b"manifest")
+    complete_wav = wav_data + metadata
+    return complete_wav[:4] + struct.pack("<I", len(complete_wav) - 8) + complete_wav[8:]
 
 
 @pytest.fixture
@@ -1111,6 +1133,50 @@ class TestOpenAIEventHandlerComprehensive:
         assert timestamp == pytest.approx(1000.0)
 
     @pytest.mark.asyncio
+    async def test_stream_audio_to_wyoming_excludes_trailing_riff_chunks(self, enhanced_handler):
+        """Test buffered WAV conversion stops at the declared PCM data boundary."""
+        pcm = b"\x00\x01" * 240
+        wav_data = _pcm_wav_with_trailing_metadata(pcm)
+
+        timestamp = await enhanced_handler._stream_audio_to_wyoming(
+            wav_data,
+            is_first_chunk=True,
+            start_timestamp=0,
+        )
+
+        audio_chunk_events = [
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "audio-chunk"
+        ]
+        emitted_audio = b"".join(event.payload for event in audio_chunk_events)
+        assert emitted_audio == pcm
+        assert b"LIST" not in emitted_audio
+        assert b"C2PA" not in emitted_audio
+        assert timestamp == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_stream_audio_to_wyoming_warns_for_truncated_wav(self, enhanced_handler, caplog):
+        """Test buffered WAV conversion reports an incomplete declared PCM payload."""
+        pcm = b"\x00\x01" * 240
+        wav_data = _pcm_wav_with_trailing_metadata(pcm)
+        wav_params = enhanced_handler._parse_wav_header(wav_data)
+        assert wav_params is not None
+        data_offset = wav_params[3]
+        truncated_wav = wav_data[: data_offset + len(pcm) - 10]
+
+        timestamp = await enhanced_handler._stream_audio_to_wyoming(
+            truncated_wav,
+            is_first_chunk=True,
+            start_timestamp=0,
+        )
+
+        audio_chunk_events = [
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "audio-chunk"
+        ]
+        assert b"".join(event.payload for event in audio_chunk_events) == pcm[:-10]
+        assert timestamp == pytest.approx(470 / 2 / 24000 * 1000)
+        assert "ended after 470 of 480 declared PCM bytes" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_stream_tts_audio_uses_frame_count_for_stereo_audio(self, enhanced_handler, mock_clients):
         """Test direct TTS streaming preserves correct stereo timing."""
         _, tts_client = mock_clients
@@ -1211,6 +1277,107 @@ class TestOpenAIEventHandlerComprehensive:
         assert audio_chunk_events
         assert audio_chunk_events[0].payload == wav_data[44:60]
         assert b"".join(event.payload for event in audio_chunk_events) == wav_data[44:]
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_audio_excludes_trailing_riff_chunks_across_http_boundaries(
+        self, enhanced_handler, mock_clients
+    ):
+        """Test incremental WAV conversion stops at the data boundary for varied HTTP chunks."""
+        _, tts_client = mock_clients
+        pcm = b"\x00\x01" * 240
+        wav_data = _pcm_wav_with_trailing_metadata(pcm)
+        wav_params = enhanced_handler._parse_wav_header(wav_data)
+        assert wav_params is not None
+        data_offset = wav_params[3]
+        data_end = data_offset + len(pcm)
+        chunk_layouts = [
+            [wav_data],
+            [wav_data[: data_end - 8], wav_data[data_end - 8 : data_end + 4], wav_data[data_end + 4 :]],
+            [wav_data[:data_end], wav_data[data_end:]],
+        ]
+
+        class MockAsyncIterator:
+            def __init__(self, chunks):
+                self.chunks = chunks
+                self.index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.index >= len(self.chunks):
+                    raise StopAsyncIteration
+                chunk = self.chunks[self.index]
+                self.index += 1
+                return chunk
+
+        voice = enhanced_handler._get_voice("alloy")
+        assert voice is not None
+
+        for chunks in chunk_layouts:
+            mock_response = Mock()
+            mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(chunks))
+            mock_stream_response = AsyncMock()
+            mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+            tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+            enhanced_handler.write_event.reset_mock()
+
+            timestamp = await enhanced_handler._stream_tts_audio(voice, "Hello world", send_audio_start=True)
+
+            audio_chunk_events = [
+                call.args[0]
+                for call in enhanced_handler.write_event.call_args_list
+                if call.args[0].type == "audio-chunk"
+            ]
+            emitted_audio = b"".join(event.payload for event in audio_chunk_events)
+            assert emitted_audio == pcm
+            assert b"LIST" not in emitted_audio
+            assert b"C2PA" not in emitted_audio
+            assert timestamp == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_audio_warns_for_truncated_wav(self, enhanced_handler, mock_clients, caplog):
+        """Test incremental WAV conversion reports missing declared PCM bytes."""
+        _, tts_client = mock_clients
+        pcm = b"\x00\x01" * 240
+        wav_data = _pcm_wav_with_trailing_metadata(pcm)
+        wav_params = enhanced_handler._parse_wav_header(wav_data)
+        assert wav_params is not None
+        data_end = wav_params[3] + len(pcm)
+        truncated_wav = wav_data[: data_end - 10]
+
+        class MockAsyncIterator:
+            def __init__(self, data):
+                self.data = data
+                self.done = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self.done:
+                    raise StopAsyncIteration
+                self.done = True
+                return self.data
+
+        mock_response = Mock()
+        mock_response.iter_bytes = Mock(return_value=MockAsyncIterator(truncated_wav))
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=None)
+        tts_client.audio.speech.with_streaming_response.create = Mock(return_value=mock_stream_response)
+        voice = enhanced_handler._get_voice("alloy")
+        assert voice is not None
+
+        timestamp = await enhanced_handler._stream_tts_audio(voice, "Hello world", send_audio_start=True)
+
+        audio_chunk_events = [
+            call.args[0] for call in enhanced_handler.write_event.call_args_list if call.args[0].type == "audio-chunk"
+        ]
+        assert b"".join(event.payload for event in audio_chunk_events) == pcm[:-10]
+        assert timestamp == pytest.approx(470 / 2 / 24000 * 1000)
+        assert "ended with 10 declared PCM bytes missing" in caplog.text
 
     @pytest.mark.asyncio
     async def test_handle_streaming_synthesis(self, enhanced_handler, mock_clients):


### PR DESCRIPTION
## Summary

- honor the declared PCM payload size when stripping WAV containers
- stop trailing RIFF chunks such as `LIST/INFO` and `C2PA` from reaching Wyoming as audio
- track the remaining PCM byte count across incremental HTTP chunks
- warn when a WAV response ends before its declared PCM payload is complete
- add buffered and incremental regression coverage with valid trailing RIFF metadata

## Issue context

Fixes #73.

This is related to but distinct from #72. Issue #72 concerns float32 WAV output that Python’s `wave` module cannot parse and would require transcoding or an upstream format change. This PR intentionally does not change that fallback behavior.

The fix is backend-independent and does not add Crisp-specific handling or C2PA parsing.

## Verification

- `pytest tests/test_handler.py -q` — 59 passed
- `pytest -q` — 138 passed
- `ruff check .` — passed
- `pyright --pythonpath ./.venv/Scripts/python.exe` — 0 errors