### PR TITLE
End-to-end integration test suite: TTS-to-STT round-trip against Speaches

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,10 +10,113 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  integration:
+  # Full e2e suite: Speaches in Docker, wyoming_openai as a pytest-managed
+  # subprocess. TTS output is round-tripped through STT and fuzzy-matched.
+  e2e-subprocess:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      COMPOSE_PROJECT_NAME: wyoming_openai
+      WYOMING_E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Restore Hugging Face model cache
+        id: hf-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: hf-cache
+          key: hf-${{ hashFiles('docker-compose.speaches-cpu.yml', 'docker-compose.e2e.yml') }}
+          restore-keys: hf-
+
+      - name: Seed docker volume from cache
+        run: |
+          mkdir -p hf-cache
+          docker volume create wyoming_openai_huggingface-hub
+          if [ -n "$(ls -A hf-cache 2>/dev/null)" ]; then
+            docker run --rm \
+              -v wyoming_openai_huggingface-hub:/dest \
+              -v "$PWD/hf-cache":/src \
+              alpine sh -c "cp -a /src/. /dest/"
+          fi
+
+      - name: Start Speaches
+        run: docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d speaches
+
+      - name: Wait for Speaches to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "Speaches healthy after ${i} polls"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Speaches did not become healthy in time"
+          docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs speaches
+          exit 1
+
+      - name: Run integration tests
+        run: pytest -m integration -v --timeout=180
+
+      # always(): save the downloaded models even when tests fail, so a rerun
+      # of a failed cold-cache run doesn't download them again.
+      - name: Snapshot HF cache for next run
+        if: always() && steps.hf-cache.outputs.cache-hit != 'true'
+        run: |
+          rm -rf hf-cache
+          mkdir -p hf-cache
+          docker run --rm \
+            -v wyoming_openai_huggingface-hub:/src \
+            -v "$PWD/hf-cache":/dest \
+            alpine sh -c "cp -a /src/. /dest/"
+
+      - name: Save Hugging Face model cache
+        if: always() && steps.hf-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: hf-cache
+          key: hf-${{ hashFiles('docker-compose.speaches-cpu.yml', 'docker-compose.e2e.yml') }}
+
+      - name: Capture logs on failure
+        if: failure()
+        run: |
+          mkdir -p "$WYOMING_E2E_ARTIFACT_DIR"
+          docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs speaches > "$WYOMING_E2E_ARTIFACT_DIR/speaches.log" 2>&1 || true
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-subprocess-artifacts
+          path: e2e-artifacts/
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml down -v
+
+  # Smoke test against the actual built Docker image: the proxy runs as a
+  # container next to Speaches, and the smoke subset of the e2e suite targets
+  # it over TCP via WYOMING_E2E_URI.
+  container-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       COMPOSE_PROJECT_NAME: wyoming_openai
     steps:
@@ -29,17 +132,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Cache Hugging Face models
-        uses: actions/cache@v4
+      # Restore only - the e2e-subprocess job owns cache saves, avoiding a
+      # write race between the two parallel jobs.
+      - name: Restore Hugging Face model cache
+        uses: actions/cache/restore@v4
         with:
           path: hf-cache
-          key: hf-${{ hashFiles('docker-compose.speaches-cpu.yml') }}
+          key: hf-${{ hashFiles('docker-compose.speaches-cpu.yml', 'docker-compose.e2e.yml') }}
+          restore-keys: hf-
 
-      - name: Restore cache into docker volume
+      - name: Seed docker volume from cache
         run: |
           mkdir -p hf-cache
           docker volume create wyoming_openai_huggingface-hub
-          # Seed the named volume from the cached directory if any.
           if [ -n "$(ls -A hf-cache 2>/dev/null)" ]; then
             docker run --rm \
               -v wyoming_openai_huggingface-hub:/dest \
@@ -47,46 +152,66 @@ jobs:
               alpine sh -c "cp -a /src/. /dest/"
           fi
 
-      - name: Start Speaches
-        run: docker compose -f docker-compose.speaches-cpu.yml up -d speaches
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Wait for Speaches to be healthy
+      # cache-from only: docker-image-pr.yml owns GHA build-cache writes.
+      - name: Build wyoming_openai image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: wyoming_openai:e2e
+          cache-from: type=gha
+
+      - name: Start the full stack
+        run: docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d
+
+      - name: Wait for the stack to be ready
         run: |
           for i in $(seq 1 60); do
             if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
               echo "Speaches healthy after ${i} polls"
-              exit 0
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "Speaches did not become healthy in time"
+              docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs
+              exit 1
             fi
             sleep 5
           done
-          echo "Speaches did not become healthy in time"
-          docker compose -f docker-compose.speaches-cpu.yml logs speaches
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 10300; then
+              echo "wyoming_openai accepting connections after ${i} polls"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "wyoming_openai did not start in time"
+          docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs wyoming_openai
           exit 1
 
-      - name: Run integration tests
-        run: pytest -m integration -v --timeout=180
+      - name: Run smoke tests against the container
+        run: pytest -m "integration and smoke" -v --timeout=180
+        env:
+          WYOMING_E2E_URI: tcp://127.0.0.1:10300
 
-      - name: Snapshot HF cache for next run
-        if: always()
-        run: |
-          rm -rf hf-cache
-          mkdir -p hf-cache
-          docker run --rm \
-            -v wyoming_openai_huggingface-hub:/src \
-            -v "$PWD/hf-cache":/dest \
-            alpine sh -c "cp -a /src/. /dest/"
-
-      - name: Capture Speaches logs on failure
+      - name: Capture logs on failure
         if: failure()
-        run: docker compose -f docker-compose.speaches-cpu.yml logs speaches > speaches.log
+        run: |
+          mkdir -p smoke-artifacts
+          docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs speaches > smoke-artifacts/speaches.log 2>&1 || true
+          docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml logs wyoming_openai > smoke-artifacts/wyoming_openai.log 2>&1 || true
 
-      - name: Upload Speaches logs
+      - name: Upload artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: speaches-logs
-          path: speaches.log
+          name: container-smoke-artifacts
+          path: smoke-artifacts/
+          if-no-files-found: ignore
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.speaches-cpu.yml down -v
+        run: docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml down -v

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,92 @@
+name: Integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      COMPOSE_PROJECT_NAME: wyoming_openai
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: hf-cache
+          key: hf-${{ hashFiles('docker-compose.speaches-cpu.yml') }}
+
+      - name: Restore cache into docker volume
+        run: |
+          mkdir -p hf-cache
+          docker volume create wyoming_openai_huggingface-hub
+          # Seed the named volume from the cached directory if any.
+          if [ -n "$(ls -A hf-cache 2>/dev/null)" ]; then
+            docker run --rm \
+              -v wyoming_openai_huggingface-hub:/dest \
+              -v "$PWD/hf-cache":/src \
+              alpine sh -c "cp -a /src/. /dest/"
+          fi
+
+      - name: Start Speaches
+        run: docker compose -f docker-compose.speaches-cpu.yml up -d speaches
+
+      - name: Wait for Speaches to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health > /dev/null; then
+              echo "Speaches healthy after ${i} polls"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Speaches did not become healthy in time"
+          docker compose -f docker-compose.speaches-cpu.yml logs speaches
+          exit 1
+
+      - name: Run integration tests
+        run: pytest -m integration -v --timeout=180
+
+      - name: Snapshot HF cache for next run
+        if: always()
+        run: |
+          rm -rf hf-cache
+          mkdir -p hf-cache
+          docker run --rm \
+            -v wyoming_openai_huggingface-hub:/src \
+            -v "$PWD/hf-cache":/dest \
+            alpine sh -c "cp -a /src/. /dest/"
+
+      - name: Capture Speaches logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.speaches-cpu.yml logs speaches > speaches.log
+
+      - name: Upload Speaches logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: speaches-logs
+          path: speaches.log
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.speaches-cpu.yml down -v

--- a/README.md
+++ b/README.md
@@ -590,3 +590,18 @@ This project uses [pytest](https://pytest.org/) for unit testing. Tests are loca
 
 All new code should include appropriate tests.
 A GitHub Action automatically runs pytest on all pull requests and branch pushes to ensure tests pass.
+
+#### End-to-End Integration Tests
+
+The `tests/test_e2e.py` suite drives a real `wyoming_openai` server over TCP and a real Speaches backend in Docker, with no Home Assistant or microphone needed. TTS output is verified by feeding it back through STT and fuzzy-matching the transcript against the original phrase.
+
+These tests are gated behind the `integration` marker and skipped by default. To run locally:
+
+```bash
+docker compose -f docker-compose.speaches-cpu.yml up -d speaches
+pytest -m integration -v
+```
+
+If Speaches is already healthy on `localhost:8000`, the fixture will reuse it. Set `WYOMING_OPENAI_KEEP_SPEACHES=1` to leave the container running between test invocations for faster iteration.
+
+A separate [Integration](.github/workflows/integration.yml) GitHub Actions workflow runs this suite on PRs against `main`.

--- a/README.md
+++ b/README.md
@@ -593,15 +593,38 @@ A GitHub Action automatically runs pytest on all pull requests and branch pushes
 
 #### End-to-End Integration Tests
 
-The `tests/test_e2e.py` suite drives a real `wyoming_openai` server over TCP and a real Speaches backend in Docker, with no Home Assistant or microphone needed. TTS output is verified by feeding it back through STT and fuzzy-matching the transcript against the original phrase.
+The `tests/test_e2e.py` suite drives a real `wyoming_openai` server over TCP and a real Speaches backend in Docker, with no Home Assistant or microphone needed. TTS output is verified by feeding it back through STT and fuzzy-matching the transcript against the original phrase (with tolerance for minor mishearing).
 
-These tests are gated behind the `integration` marker and skipped by default. To run locally:
+These tests are gated behind the `integration` marker and skipped by default. To run locally, just:
 
 ```bash
-docker compose -f docker-compose.speaches-cpu.yml up -d speaches
 pytest -m integration -v
 ```
 
-If Speaches is already healthy on `localhost:8000`, the fixture will reuse it. Set `WYOMING_OPENAI_KEEP_SPEACHES=1` to leave the container running between test invocations for faster iteration.
+The fixtures handle the backend automatically: a Speaches instance already healthy on `localhost:8000` is reused; otherwise the Docker Compose stack (`docker-compose.speaches-cpu.yml` layered with `docker-compose.e2e.yml`, which swaps in a smaller Whisper model for testing) is started and torn down; if Docker is unavailable, the suite skips. Useful environment variables:
 
-A separate [Integration](.github/workflows/integration.yml) GitHub Actions workflow runs this suite on PRs against `main`.
+- `WYOMING_OPENAI_KEEP_SPEACHES=1` - leave the Speaches container running between invocations for faster iteration (model load is the slow part).
+- `WYOMING_E2E_URI=tcp://host:port` - target an already-running proxy instead of spawning a subprocess (the autodetection test skips in this mode, since it must control the server's environment).
+- `WYOMING_E2E_ARTIFACT_DIR=<dir>` - save synthesized WAVs and server logs for debugging (CI uses this to upload artifacts on failure).
+
+To test the actual Docker image end-to-end (what the containerized CI smoke job does):
+
+```bash
+docker build -t wyoming_openai:e2e .
+docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d
+WYOMING_E2E_URI=tcp://127.0.0.1:10300 pytest -m "integration and smoke" -v
+```
+
+Or in PowerShell:
+
+```powershell
+docker build -t wyoming_openai:e2e .
+docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d
+$env:WYOMING_E2E_URI = "tcp://127.0.0.1:10300"; pytest -m "integration and smoke" -v
+```
+
+Windows note: this works under Docker Desktop; run pytest from a native Windows Python (not WSL) so subprocess spawning and localhost port publishing line up.
+
+Realtime models (`STT_REALTIME_MODELS`) are intentionally not covered - they use the OpenAI websocket API, which Speaches does not implement.
+
+The [Integration](.github/workflows/integration.yml) GitHub Actions workflow runs this suite on pushes and PRs against `main`: one job with the subprocess proxy, plus a smoke job against the freshly built Docker image.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,38 @@
+# E2E test overlay - layer on top of the general-purpose Speaches CPU stack:
+#
+#   docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d speaches
+#
+# starts only the backend (the pytest suite runs the proxy as a subprocess), while
+#
+#   docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d
+#
+# also starts the containerized proxy for smoke-testing the built image
+# (build it first: docker build -t wyoming_openai:e2e .).
+#
+# Overrides the Whisper model with a small variant (~330MB vs ~1.5GB) so CI
+# downloads less and starts faster; e2e round-trip tests only need enough
+# accuracy to fuzzy-match clean synthetic speech.
+services:
+  speaches:
+    environment:
+      WHISPER__MODEL: Systran/faster-distil-whisper-small.en
+      preload_models: '["Systran/faster-distil-whisper-small.en", "speaches-ai/Kokoro-82M-v1.0-ONNX"]'
+
+  wyoming_openai:
+    image: ${WYOMING_OPENAI_IMAGE:-wyoming_openai:e2e}
+    container_name: wyoming_openai_e2e
+    ports:
+      - "10300:10300"
+    environment:
+      WYOMING_URI: tcp://0.0.0.0:10300
+      WYOMING_LOG_LEVEL: DEBUG
+      WYOMING_LANGUAGES: en
+      STT_OPENAI_URL: http://speaches:8000/v1
+      STT_MODELS: Systran/faster-distil-whisper-small.en
+      STT_BACKEND: SPEACHES
+      TTS_OPENAI_URL: http://speaches:8000/v1
+      TTS_MODELS: speaches-ai/Kokoro-82M-v1.0-ONNX
+      TTS_BACKEND: SPEACHES
+    depends_on:
+      speaches:
+        condition: service_healthy

--- a/docker-compose.speaches-cpu.yml
+++ b/docker-compose.speaches-cpu.yml
@@ -1,0 +1,25 @@
+services:
+  speaches:
+    container_name: speaches
+    image: ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      enable_ui: False
+      log_level: info
+      WHISPER__MODEL: Systran/faster-distil-whisper-large-v3
+      WHISPER__compute_type: int8
+      preload_models: '["Systran/faster-distil-whisper-large-v3", "speaches-ai/Kokoro-82M-v1.0-ONNX"]'
+      SPEACHES_BASE_URL: http://speaches:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    volumes:
+      - huggingface-hub:/home/ubuntu/.cache/huggingface/hub
+
+volumes:
+  huggingface-hub:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,10 @@ dev = [
 [tool.pytest.ini_options]
 markers = [
     "integration: end-to-end tests that require a running Speaches docker container (opt in with: pytest -m integration)",
+    "smoke: minimal e2e subset used by the containerized CI smoke job (pytest -m 'integration and smoke')",
 ]
 addopts = "-m 'not integration'"
+pythonpath = ["tests"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,16 @@ dev = [
     "pytest-asyncio==1.3.0",
     "pytest-mock==3.15.1",
     "pytest-cov==7.1.0",
+    "pytest-timeout==2.4.0",
     "pyright==1.1.409",
+    "rapidfuzz==3.10.1",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: end-to-end tests that require a running Speaches docker container (opt in with: pytest -m integration)",
+]
+addopts = "-m 'not integration'"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,194 @@
+"""Shared pytest fixtures.
+
+Most fixtures here are dedicated to the integration suite (`-m integration`).
+The default `pytest` invocation skips that marker (see `addopts` in
+pyproject.toml) and these fixtures do not load any heavy dependencies at
+import time, so unit tests are unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from e2e_helpers import WyomingTestClient
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILE = REPO_ROOT / "docker-compose.speaches-cpu.yml"
+
+SPEACHES_HEALTH_URL = "http://127.0.0.1:8000/health"
+SPEACHES_BASE_URL = "http://127.0.0.1:8000/v1"
+SPEACHES_HEALTH_TIMEOUT_SECONDS = 240
+SPEACHES_HEALTH_POLL_INTERVAL_SECONDS = 2
+
+STT_MODEL = "Systran/faster-distil-whisper-large-v3"
+TTS_MODEL = "speaches-ai/Kokoro-82M-v1.0-ONNX"
+
+WYOMING_STARTUP_TIMEOUT_SECONDS = 30
+WYOMING_SHUTDOWN_GRACE_SECONDS = 5
+WYOMING_CONFIG_ENV_PREFIXES = ("STT_", "TTS_", "WYOMING_")
+
+
+def _is_speaches_healthy() -> bool:
+    try:
+        with urllib.request.urlopen(SPEACHES_HEALTH_URL, timeout=2) as response:
+            return response.status == 200
+    except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+        return False
+
+
+def _wait_for_speaches(timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(SPEACHES_HEALTH_URL, timeout=5) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError) as exc:
+            last_error = exc
+        time.sleep(SPEACHES_HEALTH_POLL_INTERVAL_SECONDS)
+    detail = f"; last error: {last_error}" if last_error else ""
+    raise TimeoutError(f"Speaches did not become healthy within {timeout}s{detail}")
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_tcp(host: str, port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return
+        except OSError as exc:
+            last_error = exc
+            time.sleep(0.2)
+    detail = f"; last error: {last_error}" if last_error else ""
+    raise TimeoutError(f"Wyoming server did not accept connections at {host}:{port} within {timeout}s{detail}")
+
+
+@pytest.fixture(scope="session")
+def speaches_backend() -> Generator[str, None, None]:
+    """Ensure a Speaches backend is reachable on localhost:8000.
+
+    If one is already running, reuse it. Otherwise bring up the CPU
+    docker-compose stack and tear it down on session exit (unless
+    WYOMING_OPENAI_KEEP_SPEACHES=1).
+    """
+
+    if _is_speaches_healthy():
+        yield SPEACHES_BASE_URL
+        return
+
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("docker is not available; cannot start Speaches for integration tests")
+
+    if not COMPOSE_FILE.exists():
+        pytest.skip(f"docker-compose file missing: {COMPOSE_FILE}")
+
+    up_cmd = [docker, "compose", "-f", str(COMPOSE_FILE), "up", "-d", "speaches"]
+    subprocess.run(up_cmd, check=True, cwd=REPO_ROOT)
+
+    try:
+        _wait_for_speaches(SPEACHES_HEALTH_TIMEOUT_SECONDS)
+        yield SPEACHES_BASE_URL
+    finally:
+        if os.environ.get("WYOMING_OPENAI_KEEP_SPEACHES") != "1":
+            down_cmd = [docker, "compose", "-f", str(COMPOSE_FILE), "down"]
+            subprocess.run(down_cmd, check=False, cwd=REPO_ROOT)
+
+
+def _start_wyoming_server(env_overrides: dict[str, str]) -> tuple[subprocess.Popen[bytes], int]:
+    port = _find_free_port()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(WYOMING_CONFIG_ENV_PREFIXES)
+    }
+    env.update(
+        {
+            "WYOMING_URI": f"tcp://127.0.0.1:{port}",
+            "WYOMING_LOG_LEVEL": "INFO",
+            "WYOMING_LANGUAGES": "en",
+            "STT_OPENAI_URL": SPEACHES_BASE_URL,
+            "STT_MODELS": STT_MODEL,
+            "TTS_OPENAI_URL": SPEACHES_BASE_URL,
+            "TTS_MODELS": TTS_MODEL,
+        }
+    )
+    env.update(env_overrides)
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "wyoming_openai"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=REPO_ROOT,
+    )
+    try:
+        _wait_for_tcp("127.0.0.1", port, WYOMING_STARTUP_TIMEOUT_SECONDS)
+    except Exception:
+        _terminate(proc)
+        raise
+    return proc, port
+
+
+def _terminate(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=WYOMING_SHUTDOWN_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=WYOMING_SHUTDOWN_GRACE_SECONDS)
+
+
+@pytest.fixture(scope="session")
+def wyoming_server(speaches_backend: str) -> Generator[int, None, None]:
+    """Run wyoming_openai as a subprocess pointed at the Speaches backend.
+
+    Yields the TCP port the server is listening on.
+    """
+    proc, port = _start_wyoming_server(env_overrides={"STT_BACKEND": "SPEACHES", "TTS_BACKEND": "SPEACHES"})
+    try:
+        yield port
+    finally:
+        _terminate(proc)
+
+
+@pytest.fixture(scope="session")
+def wyoming_server_autodetect(speaches_backend: str) -> Generator[int, None, None]:
+    """Run wyoming_openai without explicit backend env vars to exercise autodetection."""
+    proc, port = _start_wyoming_server(env_overrides={})
+    try:
+        yield port
+    finally:
+        _terminate(proc)
+
+
+@pytest_asyncio.fixture
+async def wyoming_client(wyoming_server: int):
+    async with WyomingTestClient(host="127.0.0.1", port=wyoming_server) as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def wyoming_client_autodetect(wyoming_server_autodetect: int):
+    async with WyomingTestClient(host="127.0.0.1", port=wyoming_server_autodetect) as client:
+        yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,15 @@ Most fixtures here are dedicated to the integration suite (`-m integration`).
 The default `pytest` invocation skips that marker (see `addopts` in
 pyproject.toml) and these fixtures do not load any heavy dependencies at
 import time, so unit tests are unaffected.
+
+Two modes:
+
+- Default: spawn `python -m wyoming_openai` as a subprocess pointed at a
+  Speaches backend (reused if already healthy on localhost:8000, otherwise
+  started via docker compose, otherwise the suite skips).
+- External: set WYOMING_E2E_URI=tcp://host:port to target an already-running
+  proxy (e.g. the containerized smoke stack). No docker or subprocess
+  management happens; tests that must control the server's environment skip.
 """
 
 from __future__ import annotations
@@ -13,30 +22,54 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from e2e_helpers import WyomingTestClient
+from e2e_helpers import ARTIFACT_DIR_ENV_VAR, WyomingTestClient
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-COMPOSE_FILE = REPO_ROOT / "docker-compose.speaches-cpu.yml"
+# The e2e overlay swaps in a smaller Whisper model; the base file keeps the
+# general-purpose default for real deployments.
+COMPOSE_FILES = [
+    REPO_ROOT / "docker-compose.speaches-cpu.yml",
+    REPO_ROOT / "docker-compose.e2e.yml",
+]
+
+EXTERNAL_URI_ENV_VAR = "WYOMING_E2E_URI"
 
 SPEACHES_HEALTH_URL = "http://127.0.0.1:8000/health"
 SPEACHES_BASE_URL = "http://127.0.0.1:8000/v1"
 SPEACHES_HEALTH_TIMEOUT_SECONDS = 240
 SPEACHES_HEALTH_POLL_INTERVAL_SECONDS = 2
 
-STT_MODEL = "Systran/faster-distil-whisper-large-v3"
-TTS_MODEL = "speaches-ai/Kokoro-82M-v1.0-ONNX"
+STT_MODEL = os.environ.get("WYOMING_E2E_STT_MODEL", "Systran/faster-distil-whisper-small.en")
+TTS_MODEL = os.environ.get("WYOMING_E2E_TTS_MODEL", "speaches-ai/Kokoro-82M-v1.0-ONNX")
 
 WYOMING_STARTUP_TIMEOUT_SECONDS = 30
 WYOMING_SHUTDOWN_GRACE_SECONDS = 5
+# Deliberately strips every proxy-related var a dev shell might export
+# (including e.g. STT_REALTIME_MODELS - realtime uses the OpenAI websocket API,
+# which Speaches does not implement, so it is out of scope for this suite).
+# Non-prefixed vars (PATH, SystemRoot, ...) are kept so the subprocess also
+# works on Windows.
 WYOMING_CONFIG_ENV_PREFIXES = ("STT_", "TTS_", "WYOMING_")
+
+
+def _external_endpoint() -> tuple[str, int] | None:
+    uri = os.environ.get(EXTERNAL_URI_ENV_VAR)
+    if not uri:
+        return None
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != "tcp" or not parsed.hostname or not parsed.port:
+        raise ValueError(f"{EXTERNAL_URI_ENV_VAR} must look like tcp://host:port, got {uri!r}")
+    return parsed.hostname, parsed.port
 
 
 def _is_speaches_healthy() -> bool:
@@ -82,13 +115,21 @@ def _wait_for_tcp(host: str, port: int, timeout: float) -> None:
     raise TimeoutError(f"Wyoming server did not accept connections at {host}:{port} within {timeout}s{detail}")
 
 
+def _compose_command(docker: str, *args: str) -> list[str]:
+    cmd = [docker, "compose"]
+    for compose_file in COMPOSE_FILES:
+        cmd.extend(["-f", str(compose_file)])
+    cmd.extend(args)
+    return cmd
+
+
 @pytest.fixture(scope="session")
 def speaches_backend() -> Generator[str, None, None]:
     """Ensure a Speaches backend is reachable on localhost:8000.
 
     If one is already running, reuse it. Otherwise bring up the CPU
-    docker-compose stack and tear it down on session exit (unless
-    WYOMING_OPENAI_KEEP_SPEACHES=1).
+    docker-compose stack (with the e2e model overlay) and tear it down on
+    session exit (unless WYOMING_OPENAI_KEEP_SPEACHES=1).
     """
 
     if _is_speaches_healthy():
@@ -99,22 +140,21 @@ def speaches_backend() -> Generator[str, None, None]:
     if docker is None:
         pytest.skip("docker is not available; cannot start Speaches for integration tests")
 
-    if not COMPOSE_FILE.exists():
-        pytest.skip(f"docker-compose file missing: {COMPOSE_FILE}")
+    missing = [str(f) for f in COMPOSE_FILES if not f.exists()]
+    if missing:
+        pytest.skip(f"docker-compose file(s) missing: {', '.join(missing)}")
 
-    up_cmd = [docker, "compose", "-f", str(COMPOSE_FILE), "up", "-d", "speaches"]
-    subprocess.run(up_cmd, check=True, cwd=REPO_ROOT)
+    subprocess.run(_compose_command(docker, "up", "-d", "speaches"), check=True, cwd=REPO_ROOT)
 
     try:
         _wait_for_speaches(SPEACHES_HEALTH_TIMEOUT_SECONDS)
         yield SPEACHES_BASE_URL
     finally:
         if os.environ.get("WYOMING_OPENAI_KEEP_SPEACHES") != "1":
-            down_cmd = [docker, "compose", "-f", str(COMPOSE_FILE), "down"]
-            subprocess.run(down_cmd, check=False, cwd=REPO_ROOT)
+            subprocess.run(_compose_command(docker, "down"), check=False, cwd=REPO_ROOT)
 
 
-def _start_wyoming_server(env_overrides: dict[str, str]) -> tuple[subprocess.Popen[bytes], int]:
+def _start_wyoming_server(env_overrides: dict[str, str]) -> tuple[subprocess.Popen[bytes], int, Path]:
     port = _find_free_port()
     env = {
         key: value
@@ -133,19 +173,30 @@ def _start_wyoming_server(env_overrides: dict[str, str]) -> tuple[subprocess.Pop
         }
     )
     env.update(env_overrides)
+
+    # Log to a file rather than a PIPE: nothing drains a PIPE, so a chatty
+    # server would eventually fill the 64KB buffer and block mid-test.
+    log_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+        mode="wb", prefix=f"wyoming-e2e-{port}-", suffix=".log", delete=False
+    )
+    log_path = Path(log_file.name)
     proc = subprocess.Popen(
         [sys.executable, "-m", "wyoming_openai"],
         env=env,
-        stdout=subprocess.PIPE,
+        stdout=log_file,
         stderr=subprocess.STDOUT,
         cwd=REPO_ROOT,
     )
+    log_file.close()
     try:
         _wait_for_tcp("127.0.0.1", port, WYOMING_STARTUP_TIMEOUT_SECONDS)
     except Exception:
+        # The server log is the most relevant diagnostic when startup fails;
+        # the fixture teardown that would normally preserve it never runs.
         _terminate(proc)
+        _preserve_log(log_path, "wyoming-subprocess-startup-failure")
         raise
-    return proc, port
+    return proc, port, log_path
 
 
 def _terminate(proc: subprocess.Popen[bytes]) -> None:
@@ -159,36 +210,79 @@ def _terminate(proc: subprocess.Popen[bytes]) -> None:
         proc.wait(timeout=WYOMING_SHUTDOWN_GRACE_SECONDS)
 
 
-@pytest.fixture(scope="session")
-def wyoming_server(speaches_backend: str) -> Generator[int, None, None]:
-    """Run wyoming_openai as a subprocess pointed at the Speaches backend.
+def _preserve_log(log_path: Path, label: str) -> None:
+    """Copy the server log into $WYOMING_E2E_ARTIFACT_DIR (if set), then remove it.
 
-    Yields the TCP port the server is listening on.
+    The temp file is always deleted so local runs don't accumulate logs
+    indefinitely; the artifact copy (CI) is what survives.
     """
-    proc, port = _start_wyoming_server(env_overrides={"STT_BACKEND": "SPEACHES", "TTS_BACKEND": "SPEACHES"})
-    try:
-        yield port
-    finally:
-        _terminate(proc)
+    artifact_dir = os.environ.get(ARTIFACT_DIR_ENV_VAR)
+    if artifact_dir and log_path.exists():
+        dest = Path(artifact_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(log_path, dest / f"{label}.log")
+    # Best-effort: on Windows the file can stay locked briefly after the
+    # process exits; never let cleanup fail teardown.
+    for _ in range(5):
+        try:
+            log_path.unlink(missing_ok=True)
+        except PermissionError:
+            time.sleep(0.2)
+        else:
+            break
 
 
 @pytest.fixture(scope="session")
-def wyoming_server_autodetect(speaches_backend: str) -> Generator[int, None, None]:
-    """Run wyoming_openai without explicit backend env vars to exercise autodetection."""
-    proc, port = _start_wyoming_server(env_overrides={})
+def wyoming_endpoint(request: pytest.FixtureRequest) -> Generator[tuple[str, int], None, None]:
+    """(host, port) of the proxy under test.
+
+    External mode (WYOMING_E2E_URI set): just wait for the port and yield.
+    Otherwise: ensure Speaches, spawn the proxy subprocess, yield, terminate.
+    """
+    external = _external_endpoint()
+    if external is not None:
+        _wait_for_tcp(*external, WYOMING_STARTUP_TIMEOUT_SECONDS)
+        yield external
+        return
+
+    request.getfixturevalue("speaches_backend")
+    proc, port, log_path = _start_wyoming_server(
+        env_overrides={"STT_BACKEND": "SPEACHES", "TTS_BACKEND": "SPEACHES"}
+    )
     try:
-        yield port
+        yield ("127.0.0.1", port)
     finally:
         _terminate(proc)
+        _preserve_log(log_path, "wyoming-subprocess")
+
+
+@pytest.fixture(scope="session")
+def wyoming_endpoint_autodetect(request: pytest.FixtureRequest) -> Generator[tuple[str, int], None, None]:
+    """Proxy spawned without explicit backend env vars to exercise autodetection.
+
+    Skips in external mode: an external server's environment cannot be controlled.
+    """
+    if _external_endpoint() is not None:
+        pytest.skip("autodetection test requires a locally spawned server (WYOMING_E2E_URI is set)")
+
+    request.getfixturevalue("speaches_backend")
+    proc, port, log_path = _start_wyoming_server(env_overrides={})
+    try:
+        yield ("127.0.0.1", port)
+    finally:
+        _terminate(proc)
+        _preserve_log(log_path, "wyoming-subprocess-autodetect")
 
 
 @pytest_asyncio.fixture
-async def wyoming_client(wyoming_server: int):
-    async with WyomingTestClient(host="127.0.0.1", port=wyoming_server) as client:
+async def wyoming_client(wyoming_endpoint: tuple[str, int]):
+    host, port = wyoming_endpoint
+    async with WyomingTestClient(host=host, port=port) as client:
         yield client
 
 
 @pytest_asyncio.fixture
-async def wyoming_client_autodetect(wyoming_server_autodetect: int):
-    async with WyomingTestClient(host="127.0.0.1", port=wyoming_server_autodetect) as client:
+async def wyoming_client_autodetect(wyoming_endpoint_autodetect: tuple[str, int]):
+    host, port = wyoming_endpoint_autodetect
+    async with WyomingTestClient(host=host, port=port) as client:
         yield client

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -1,0 +1,199 @@
+"""End-to-end test helpers for the Wyoming OpenAI proxy.
+
+These utilities drive a real running wyoming_openai TCP server from pytest,
+standing in for Home Assistant. They are only used by tests under the
+`integration` marker.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import string
+import wave
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+
+from rapidfuzz import fuzz
+from wyoming.asr import Transcribe, Transcript, TranscriptChunk, TranscriptStart, TranscriptStop
+from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.client import AsyncTcpClient
+from wyoming.event import Event
+from wyoming.info import Describe, Info
+from wyoming.tts import Synthesize, SynthesizeChunk, SynthesizeStart, SynthesizeStop, SynthesizeVoice
+
+AUDIO_CHUNK_FRAMES = 1024
+
+
+@dataclass
+class SynthesizedAudio:
+    """A complete audio response captured from the TTS pipeline."""
+
+    rate: int
+    width: int
+    channels: int
+    pcm: bytes
+    chunk_count: int
+
+    def to_wav_bytes(self) -> bytes:
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav:
+            wav.setnchannels(self.channels)
+            wav.setsampwidth(self.width)
+            wav.setframerate(self.rate)
+            wav.writeframes(self.pcm)
+        return buffer.getvalue()
+
+
+class WyomingTestClient:
+    """Convenience wrapper around `wyoming.client.AsyncTcpClient`.
+
+    Exposes describe/transcribe/synthesize methods that mirror what a Wyoming
+    consumer like Home Assistant would do, so tests can verify the full TCP
+    surface without depending on HA itself.
+    """
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 10300) -> None:
+        self.host = host
+        self.port = port
+        self._client: AsyncTcpClient | None = None
+
+    async def __aenter__(self) -> WyomingTestClient:
+        self._client = AsyncTcpClient(self.host, self.port)
+        await self._client.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._client is not None:
+            await self._client.disconnect()
+            self._client = None
+
+    @property
+    def client(self) -> AsyncTcpClient:
+        if self._client is None:
+            raise RuntimeError("WyomingTestClient must be used as an async context manager")
+        return self._client
+
+    async def _read_required(self) -> Event:
+        event = await self.client.read_event()
+        if event is None:
+            raise RuntimeError("Server closed the connection before sending the expected event")
+        return event
+
+    async def describe(self) -> Info:
+        await self.client.write_event(Describe().event())
+        while True:
+            event = await self._read_required()
+            if Info.is_type(event.type):
+                return Info.from_event(event)
+
+    async def transcribe(self, wav_bytes: bytes, model: str | None = None, language: str = "en") -> str:
+        with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+            rate = wav.getframerate()
+            width = wav.getsampwidth()
+            channels = wav.getnchannels()
+            pcm = wav.readframes(wav.getnframes())
+
+        await self.client.write_event(Transcribe(name=model, language=language).event())
+        await self.client.write_event(AudioStart(rate=rate, width=width, channels=channels).event())
+
+        bytes_per_frame = width * channels
+        chunk_size = AUDIO_CHUNK_FRAMES * bytes_per_frame
+        for start in range(0, len(pcm), chunk_size):
+            chunk = pcm[start : start + chunk_size]
+            await self.client.write_event(
+                AudioChunk(rate=rate, width=width, channels=channels, audio=chunk).event()
+            )
+        await self.client.write_event(AudioStop().event())
+
+        streamed_text = ""
+        while True:
+            event = await self._read_required()
+            if TranscriptStart.is_type(event.type):
+                continue
+            if TranscriptChunk.is_type(event.type):
+                streamed_text += TranscriptChunk.from_event(event).text
+                continue
+            if Transcript.is_type(event.type):
+                return Transcript.from_event(event).text
+            if TranscriptStop.is_type(event.type):
+                return streamed_text
+
+    async def synthesize(self, text: str, voice: str | None = None) -> SynthesizedAudio:
+        synth_voice = SynthesizeVoice(name=voice) if voice else None
+        await self.client.write_event(Synthesize(text=text, voice=synth_voice).event())
+        return await self._collect_audio()
+
+    async def synthesize_streaming(self, text: str, voice: str | None = None) -> SynthesizedAudio:
+        synth_voice = SynthesizeVoice(name=voice) if voice else None
+        await self.client.write_event(SynthesizeStart(voice=synth_voice).event())
+        await self.client.write_event(SynthesizeChunk(text=text).event())
+        await self.client.write_event(SynthesizeStop().event())
+        return await self._collect_audio()
+
+    async def _collect_audio(self) -> SynthesizedAudio:
+        rate: int | None = None
+        width: int | None = None
+        channels: int | None = None
+        pcm = bytearray()
+        chunk_count = 0
+        while True:
+            event = await self._read_required()
+            if AudioStart.is_type(event.type):
+                start = AudioStart.from_event(event)
+                rate, width, channels = start.rate, start.width, start.channels
+                continue
+            if AudioChunk.is_type(event.type):
+                chunk = AudioChunk.from_event(event)
+                pcm.extend(chunk.audio)
+                chunk_count += 1
+                if rate is None:
+                    rate, width, channels = chunk.rate, chunk.width, chunk.channels
+                continue
+            if AudioStop.is_type(event.type):
+                break
+        if rate is None or width is None or channels is None:
+            raise RuntimeError("TTS response did not include audio format information")
+        return SynthesizedAudio(rate=rate, width=width, channels=channels, pcm=bytes(pcm), chunk_count=chunk_count)
+
+    async def stream_audio_chunks(self, text: str, voice: str | None = None) -> AsyncIterator[Event]:
+        synth_voice = SynthesizeVoice(name=voice) if voice else None
+        await self.client.write_event(Synthesize(text=text, voice=synth_voice).event())
+        while True:
+            event = await self._read_required()
+            yield event
+            if AudioStop.is_type(event.type):
+                return
+
+
+_PUNCT_RE = re.compile(f"[{re.escape(string.punctuation)}]")
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize(text: str) -> str:
+    text = text.lower()
+    text = _PUNCT_RE.sub(" ", text)
+    return _WS_RE.sub(" ", text).strip()
+
+
+def fuzzy_text_match(transcript: str, expected: str, threshold: float = 0.7, coverage_threshold: float = 0.75) -> bool:
+    """True if `transcript` matches `expected` after lowercasing/punctuation strip.
+
+    Uses rapidfuzz partial_ratio so leading/trailing artifacts (e.g. Whisper
+    capitalizing the first word, dropping a trailing period, or hallucinating
+    a leading "..." token) don't fail the match. Thresholds are 0-1 fractions.
+    """
+    if not transcript or not expected:
+        return False
+
+    normalized_transcript = _normalize(transcript)
+    normalized_expected = _normalize(expected)
+    if not normalized_transcript or not normalized_expected:
+        return False
+
+    coverage = min(len(normalized_transcript), len(normalized_expected)) / len(normalized_expected)
+    if coverage < coverage_threshold:
+        return False
+
+    score = fuzz.partial_ratio(normalized_transcript, normalized_expected)
+    return score >= threshold * 100

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -111,7 +111,13 @@ class WyomingTestClient:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         if self._client is not None:
-            await self._client.disconnect()
+            try:
+                await self._client.disconnect()
+            except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+                # disconnect() flushes buffered writes; when the server already
+                # reset the connection (the negative tests induce exactly this),
+                # that flush can fail. A dead connection at teardown is fine.
+                pass
             self._client = None
 
     @property
@@ -141,6 +147,10 @@ class WyomingTestClient:
             raise WyomingTimeoutError(
                 f"No event within {self._event_timeout}s while waiting for {expecting}"
             ) from exc
+        except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError) as exc:
+            # A hard reset (RST) surfaces as an error rather than the clean
+            # None-on-EOF path below; normalize both to the same exception.
+            raise WyomingServerClosedError(f"Connection reset while waiting for {expecting}") from exc
         if event is None:
             raise WyomingServerClosedError(f"Connection closed while waiting for {expecting}")
         return event

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -7,12 +7,15 @@ standing in for Home Assistant. They are only used by tests under the
 
 from __future__ import annotations
 
+import asyncio
 import io
+import os
 import re
 import string
 import wave
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 
 from rapidfuzz import fuzz
 from wyoming.asr import Transcribe, Transcript, TranscriptChunk, TranscriptStart, TranscriptStop
@@ -20,9 +23,35 @@ from wyoming.audio import AudioChunk, AudioStart, AudioStop
 from wyoming.client import AsyncTcpClient
 from wyoming.event import Event
 from wyoming.info import Describe, Info
-from wyoming.tts import Synthesize, SynthesizeChunk, SynthesizeStart, SynthesizeStop, SynthesizeVoice
+from wyoming.tts import (
+    Synthesize,
+    SynthesizeChunk,
+    SynthesizeStart,
+    SynthesizeStop,
+    SynthesizeStopped,
+    SynthesizeVoice,
+)
 
 AUDIO_CHUNK_FRAMES = 1024
+DEFAULT_EVENT_TIMEOUT_SECONDS = 30.0
+DEFAULT_OPERATION_TIMEOUT_SECONDS = 120.0
+
+# When set, save_debug_wav() writes synthesized audio here so CI can upload it
+# as an artifact for human listening when a round-trip assertion fails.
+ARTIFACT_DIR_ENV_VAR = "WYOMING_E2E_ARTIFACT_DIR"
+
+
+class WyomingServerClosedError(RuntimeError):
+    """Server closed the TCP connection before sending the expected event.
+
+    wyoming_openai rejects unknown models/voices by returning False from its
+    event handler, which makes the wyoming server close the socket without any
+    error event - so this is the expected failure mode for negative tests.
+    """
+
+
+class WyomingTimeoutError(TimeoutError):
+    """Server did not send the expected event in time."""
 
 
 @dataclass
@@ -34,6 +63,7 @@ class SynthesizedAudio:
     channels: int
     pcm: bytes
     chunk_count: int
+    event_types: list[str] = field(default_factory=list)
 
     def to_wav_bytes(self) -> bytes:
         buffer = io.BytesIO()
@@ -45,6 +75,14 @@ class SynthesizedAudio:
         return buffer.getvalue()
 
 
+@dataclass
+class TranscriptionResult:
+    """A complete transcription response captured from the STT pipeline."""
+
+    text: str
+    event_types: list[str] = field(default_factory=list)
+
+
 class WyomingTestClient:
     """Convenience wrapper around `wyoming.client.AsyncTcpClient`.
 
@@ -53,9 +91,17 @@ class WyomingTestClient:
     surface without depending on HA itself.
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 10300) -> None:
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 10300,
+        event_timeout: float = DEFAULT_EVENT_TIMEOUT_SECONDS,
+        operation_timeout: float = DEFAULT_OPERATION_TIMEOUT_SECONDS,
+    ) -> None:
         self.host = host
         self.port = port
+        self._event_timeout = event_timeout
+        self._operation_timeout = operation_timeout
         self._client: AsyncTcpClient | None = None
 
     async def __aenter__(self) -> WyomingTestClient:
@@ -74,93 +120,136 @@ class WyomingTestClient:
             raise RuntimeError("WyomingTestClient must be used as an async context manager")
         return self._client
 
-    async def _read_required(self) -> Event:
-        event = await self.client.read_event()
+    async def _write_event(self, event: Event) -> None:
+        """Write an event, normalizing write-side disconnects.
+
+        When the server rejects an earlier event it closes the connection
+        immediately; depending on timing, a subsequent write can then raise a
+        connection error before any read observes the closure. Translate those
+        into WyomingServerClosedError so callers (especially negative tests)
+        see one consistent failure mode.
+        """
+        try:
+            await self.client.write_event(event)
+        except (ConnectionResetError, BrokenPipeError, ConnectionAbortedError) as exc:
+            raise WyomingServerClosedError(f"Connection closed while writing {event.type}") from exc
+
+    async def _read_required(self, expecting: str) -> Event:
+        try:
+            event = await asyncio.wait_for(self.client.read_event(), timeout=self._event_timeout)
+        except TimeoutError as exc:
+            raise WyomingTimeoutError(
+                f"No event within {self._event_timeout}s while waiting for {expecting}"
+            ) from exc
         if event is None:
-            raise RuntimeError("Server closed the connection before sending the expected event")
+            raise WyomingServerClosedError(f"Connection closed while waiting for {expecting}")
         return event
 
     async def describe(self) -> Info:
-        await self.client.write_event(Describe().event())
-        while True:
-            event = await self._read_required()
-            if Info.is_type(event.type):
-                return Info.from_event(event)
+        await self._write_event(Describe().event())
+        async with asyncio.timeout(self._operation_timeout):
+            while True:
+                event = await self._read_required("info")
+                if Info.is_type(event.type):
+                    return Info.from_event(event)
 
-    async def transcribe(self, wav_bytes: bytes, model: str | None = None, language: str = "en") -> str:
+    async def transcribe(
+        self, wav_bytes: bytes, model: str | None = None, language: str = "en"
+    ) -> TranscriptionResult:
         with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
             rate = wav.getframerate()
             width = wav.getsampwidth()
             channels = wav.getnchannels()
             pcm = wav.readframes(wav.getnframes())
 
-        await self.client.write_event(Transcribe(name=model, language=language).event())
-        await self.client.write_event(AudioStart(rate=rate, width=width, channels=channels).event())
+        await self._write_event(Transcribe(name=model, language=language).event())
+        await self._write_event(AudioStart(rate=rate, width=width, channels=channels).event())
 
         bytes_per_frame = width * channels
         chunk_size = AUDIO_CHUNK_FRAMES * bytes_per_frame
         for start in range(0, len(pcm), chunk_size):
             chunk = pcm[start : start + chunk_size]
-            await self.client.write_event(
+            await self._write_event(
                 AudioChunk(rate=rate, width=width, channels=channels, audio=chunk).event()
             )
-        await self.client.write_event(AudioStop().event())
+        await self._write_event(AudioStop().event())
 
+        event_types: list[str] = []
         streamed_text = ""
-        while True:
-            event = await self._read_required()
-            if TranscriptStart.is_type(event.type):
-                continue
-            if TranscriptChunk.is_type(event.type):
-                streamed_text += TranscriptChunk.from_event(event).text
-                continue
-            if Transcript.is_type(event.type):
-                return Transcript.from_event(event).text
-            if TranscriptStop.is_type(event.type):
-                return streamed_text
+        final_text: str | None = None
+        async with asyncio.timeout(self._operation_timeout):
+            while True:
+                event = await self._read_required("transcript events")
+                event_types.append(event.type)
+                if TranscriptChunk.is_type(event.type):
+                    streamed_text += TranscriptChunk.from_event(event).text
+                elif Transcript.is_type(event.type):
+                    final_text = Transcript.from_event(event).text
+                elif TranscriptStop.is_type(event.type):
+                    break
+                elif not TranscriptStart.is_type(event.type):
+                    raise RuntimeError(f"Unexpected event during transcription: {event.type}")
+        text = final_text if final_text is not None else streamed_text
+        return TranscriptionResult(text=text, event_types=event_types)
 
     async def synthesize(self, text: str, voice: str | None = None) -> SynthesizedAudio:
         synth_voice = SynthesizeVoice(name=voice) if voice else None
-        await self.client.write_event(Synthesize(text=text, voice=synth_voice).event())
+        await self._write_event(Synthesize(text=text, voice=synth_voice).event())
         return await self._collect_audio()
 
     async def synthesize_streaming(self, text: str, voice: str | None = None) -> SynthesizedAudio:
         synth_voice = SynthesizeVoice(name=voice) if voice else None
-        await self.client.write_event(SynthesizeStart(voice=synth_voice).event())
-        await self.client.write_event(SynthesizeChunk(text=text).event())
-        await self.client.write_event(SynthesizeStop().event())
-        return await self._collect_audio()
+        await self._write_event(SynthesizeStart(voice=synth_voice).event())
+        await self._write_event(SynthesizeChunk(text=text).event())
+        await self._write_event(SynthesizeStop().event())
+        return await self._collect_audio(expect_synthesize_stopped=True)
 
-    async def _collect_audio(self) -> SynthesizedAudio:
+    async def _collect_audio(self, expect_synthesize_stopped: bool = False) -> SynthesizedAudio:
         rate: int | None = None
         width: int | None = None
         channels: int | None = None
         pcm = bytearray()
         chunk_count = 0
-        while True:
-            event = await self._read_required()
-            if AudioStart.is_type(event.type):
-                start = AudioStart.from_event(event)
-                rate, width, channels = start.rate, start.width, start.channels
-                continue
-            if AudioChunk.is_type(event.type):
-                chunk = AudioChunk.from_event(event)
-                pcm.extend(chunk.audio)
-                chunk_count += 1
-                if rate is None:
-                    rate, width, channels = chunk.rate, chunk.width, chunk.channels
-                continue
-            if AudioStop.is_type(event.type):
-                break
+        event_types: list[str] = []
+        async with asyncio.timeout(self._operation_timeout):
+            while True:
+                event = await self._read_required("audio events")
+                event_types.append(event.type)
+                if AudioStart.is_type(event.type):
+                    start = AudioStart.from_event(event)
+                    rate, width, channels = start.rate, start.width, start.channels
+                    continue
+                if AudioChunk.is_type(event.type):
+                    chunk = AudioChunk.from_event(event)
+                    pcm.extend(chunk.audio)
+                    chunk_count += 1
+                    if rate is None:
+                        rate, width, channels = chunk.rate, chunk.width, chunk.channels
+                    continue
+                if AudioStop.is_type(event.type):
+                    break
+            if expect_synthesize_stopped:
+                while True:
+                    event = await self._read_required("synthesize-stopped")
+                    event_types.append(event.type)
+                    if SynthesizeStopped.is_type(event.type):
+                        break
         if rate is None or width is None or channels is None:
             raise RuntimeError("TTS response did not include audio format information")
-        return SynthesizedAudio(rate=rate, width=width, channels=channels, pcm=bytes(pcm), chunk_count=chunk_count)
+        return SynthesizedAudio(
+            rate=rate,
+            width=width,
+            channels=channels,
+            pcm=bytes(pcm),
+            chunk_count=chunk_count,
+            event_types=event_types,
+        )
 
     async def stream_audio_chunks(self, text: str, voice: str | None = None) -> AsyncIterator[Event]:
         synth_voice = SynthesizeVoice(name=voice) if voice else None
-        await self.client.write_event(Synthesize(text=text, voice=synth_voice).event())
+        await self._write_event(Synthesize(text=text, voice=synth_voice).event())
         while True:
-            event = await self._read_required()
+            event = await self._read_required("audio events")
             yield event
             if AudioStop.is_type(event.type):
                 return
@@ -176,24 +265,79 @@ def _normalize(text: str) -> str:
     return _WS_RE.sub(" ", text).strip()
 
 
-def fuzzy_text_match(transcript: str, expected: str, threshold: float = 0.7, coverage_threshold: float = 0.75) -> bool:
-    """True if `transcript` matches `expected` after lowercasing/punctuation strip.
+@dataclass
+class FuzzyMatchResult:
+    matched: bool
+    score: float  # rapidfuzz partial_ratio, 0-100
+    coverage: float
+    normalized_transcript: str
+    normalized_expected: str
+
+
+def fuzzy_match(
+    transcript: str, expected: str, threshold: float = 0.7, coverage_threshold: float = 0.75
+) -> FuzzyMatchResult:
+    """Compare `transcript` to `expected` after lowercasing/punctuation strip.
 
     Uses rapidfuzz partial_ratio so leading/trailing artifacts (e.g. Whisper
     capitalizing the first word, dropping a trailing period, or hallucinating
     a leading "..." token) don't fail the match. Thresholds are 0-1 fractions.
+    The coverage check rejects short substrings that would otherwise get a
+    perfect partial_ratio score.
     """
-    if not transcript or not expected:
-        return False
-
-    normalized_transcript = _normalize(transcript)
-    normalized_expected = _normalize(expected)
+    normalized_transcript = _normalize(transcript) if transcript else ""
+    normalized_expected = _normalize(expected) if expected else ""
     if not normalized_transcript or not normalized_expected:
-        return False
+        return FuzzyMatchResult(
+            matched=False,
+            score=0.0,
+            coverage=0.0,
+            normalized_transcript=normalized_transcript,
+            normalized_expected=normalized_expected,
+        )
 
     coverage = min(len(normalized_transcript), len(normalized_expected)) / len(normalized_expected)
-    if coverage < coverage_threshold:
-        return False
+    score = float(fuzz.partial_ratio(normalized_transcript, normalized_expected))
+    matched = coverage >= coverage_threshold and score >= threshold * 100
+    return FuzzyMatchResult(
+        matched=matched,
+        score=score,
+        coverage=coverage,
+        normalized_transcript=normalized_transcript,
+        normalized_expected=normalized_expected,
+    )
 
-    score = fuzz.partial_ratio(normalized_transcript, normalized_expected)
-    return score >= threshold * 100
+
+def fuzzy_text_match(
+    transcript: str, expected: str, threshold: float = 0.7, coverage_threshold: float = 0.75
+) -> bool:
+    """True if `transcript` matches `expected`. See fuzzy_match for details."""
+    return fuzzy_match(transcript, expected, threshold, coverage_threshold).matched
+
+
+def assert_fuzzy_match(
+    transcript: str, expected: str, threshold: float = 0.7, coverage_threshold: float = 0.75
+) -> None:
+    """Assert a fuzzy match, reporting score/coverage details on failure."""
+    result = fuzzy_match(transcript, expected, threshold, coverage_threshold)
+    assert result.matched, (
+        f"Round-trip transcript did not match "
+        f"(score={result.score:.1f}, need>={threshold * 100:.0f}, "
+        f"coverage={result.coverage:.2f}, need>={coverage_threshold:.2f})\n"
+        f"  expected: {result.normalized_expected!r}\n"
+        f"  got:      {result.normalized_transcript!r}"
+    )
+
+
+def save_debug_wav(name: str, audio: SynthesizedAudio) -> None:
+    """Write synthesized audio to $WYOMING_E2E_ARTIFACT_DIR for CI artifact upload.
+
+    No-op when the environment variable is unset (local runs).
+    """
+    artifact_dir = os.environ.get(ARTIFACT_DIR_ENV_VAR)
+    if not artifact_dir:
+        return
+    safe_name = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("_") or "audio"
+    path = Path(artifact_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    (path / f"{safe_name}.wav").write_bytes(audio.to_wav_bytes())

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,10 +2,12 @@
 
 Skipped by default. To run:
 
-    docker compose -f docker-compose.speaches-cpu.yml up -d speaches
+    docker compose -f docker-compose.speaches-cpu.yml -f docker-compose.e2e.yml up -d speaches
     pytest -m integration
 
 Or, if Speaches is already running on localhost:8000, just `pytest -m integration`.
+Tests marked `smoke` additionally run in CI against the containerized proxy
+image (see .github/workflows/integration.yml).
 """
 
 from __future__ import annotations
@@ -14,11 +16,19 @@ import io
 import wave
 
 import pytest
-from e2e_helpers import WyomingTestClient, fuzzy_text_match
+from e2e_helpers import WyomingTestClient, assert_fuzzy_match, save_debug_wav
 
 pytestmark = pytest.mark.integration
 
 MIN_TTS_PCM_BYTES = 8000
+
+ROUND_TRIP_PHRASES = [
+    pytest.param("The quick brown fox jumps over the lazy dog.", 0.7, id="pangram", marks=pytest.mark.smoke),
+    pytest.param("Turn on the kitchen lights.", 0.7, id="command"),
+    # Digits/homophones ("five" vs "5") get a slightly looser threshold.
+    pytest.param("Set a timer for five minutes.", 0.65, id="digits"),
+    pytest.param("What's the weather like tomorrow in Berlin?", 0.7, id="question"),
+]
 
 
 def _first_voice_name(info) -> str | None:
@@ -28,6 +38,14 @@ def _first_voice_name(info) -> str | None:
     return None
 
 
+def _first_asr_model_name(info) -> str | None:
+    for asr_program in info.asr:
+        if asr_program.models:
+            return asr_program.models[0].name
+    return None
+
+
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_describe_returns_speaches_models(wyoming_client: WyomingTestClient) -> None:
     info = await wyoming_client.describe()
@@ -53,12 +71,20 @@ async def test_tts_structural(wyoming_client: WyomingTestClient) -> None:
         f"TTS produced suspiciously little audio: {len(audio.pcm)} bytes"
     )
 
+    # Event ordering: audio-start, then only chunks, then audio-stop.
+    assert audio.event_types[0] == "audio-start"
+    assert audio.event_types[-1] == "audio-stop"
+    middle = audio.event_types[1:-1]
+    assert middle, "expected at least one audio-chunk between start and stop"
+    assert all(event_type == "audio-chunk" for event_type in middle), audio.event_types
+
     with wave.open(io.BytesIO(audio.to_wav_bytes()), "rb") as wav:
         assert wav.getframerate() == audio.rate
         assert wav.getnchannels() == audio.channels
         assert wav.getsampwidth() == audio.width
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_tts_streaming_structural(wyoming_client: WyomingTestClient) -> None:
     info = await wyoming_client.describe()
@@ -69,39 +95,70 @@ async def test_tts_streaming_structural(wyoming_client: WyomingTestClient) -> No
     assert audio.chunk_count >= 1
     assert len(audio.pcm) >= MIN_TTS_PCM_BYTES
 
+    # Streaming synthesis ends with synthesize-stopped after the audio stream.
+    assert audio.event_types[0] == "audio-start"
+    assert audio.event_types[-1] == "synthesize-stopped"
+    assert audio.event_types[-2] == "audio-stop"
+
 
 @pytest.mark.asyncio
-async def test_stt_from_synthesized_audio(wyoming_client: WyomingTestClient) -> None:
+@pytest.mark.parametrize(("phrase", "threshold"), ROUND_TRIP_PHRASES)
+async def test_stt_round_trip(wyoming_client: WyomingTestClient, phrase: str, threshold: float) -> None:
     """The killer test: synthesize text, transcribe it, assert the loop closes.
 
     No human listening required - if TTS produces silence or STT returns
-    garbage, fuzzy_text_match will catch it.
+    garbage, the fuzzy match will catch it.
     """
     info = await wyoming_client.describe()
     voice = _first_voice_name(info)
-    phrase = "The quick brown fox jumps over the lazy dog."
 
     audio = await wyoming_client.synthesize(phrase, voice=voice)
-    transcript = await wyoming_client.transcribe(audio.to_wav_bytes())
+    save_debug_wav(f"round_trip_{phrase[:24]}", audio)
+    result = await wyoming_client.transcribe(audio.to_wav_bytes())
 
-    assert transcript.strip(), "STT returned empty transcript"
-    assert fuzzy_text_match(transcript, phrase), (
-        f"Round-trip transcript did not match.\n  expected: {phrase!r}\n  got:      {transcript!r}"
-    )
+    assert result.text.strip(), "STT returned empty transcript"
+    assert_fuzzy_match(result.text, phrase, threshold=threshold)
+
+    # Transcript event contract: starts with transcript-start, exactly one
+    # final transcript, ends with transcript-stop; any transcript-chunks
+    # (streaming models) fall in between.
+    assert result.event_types[0] == "transcript-start", result.event_types
+    assert result.event_types[-1] == "transcript-stop", result.event_types
+    assert result.event_types.count("transcript") == 1, result.event_types
 
 
 @pytest.mark.asyncio
-async def test_stt_round_trip_short_phrase(wyoming_client: WyomingTestClient) -> None:
+async def test_stt_round_trip_streaming_synthesis(wyoming_client: WyomingTestClient) -> None:
+    """Round trip via the streaming TTS path (SynthesizeStart/Chunk/Stop)."""
     info = await wyoming_client.describe()
     voice = _first_voice_name(info)
-    phrase = "Turn on the kitchen lights."
+    phrase = "Streaming synthesis should still be understandable."
+
+    audio = await wyoming_client.synthesize_streaming(phrase, voice=voice)
+    save_debug_wav("round_trip_streaming", audio)
+    result = await wyoming_client.transcribe(audio.to_wav_bytes())
+
+    assert result.text.strip(), "STT returned empty transcript"
+    assert_fuzzy_match(result.text, phrase)
+
+
+@pytest.mark.asyncio
+async def test_stt_with_explicit_model(wyoming_client: WyomingTestClient) -> None:
+    """Transcribe with an explicit model name (exercises the Transcribe(name=...) path).
+
+    The model name is read from Describe so this works in both subprocess and
+    external (containerized) modes.
+    """
+    info = await wyoming_client.describe()
+    voice = _first_voice_name(info)
+    model = _first_asr_model_name(info)
+    assert model is not None, "No ASR model advertised"
+    phrase = "Explicit model selection works."
 
     audio = await wyoming_client.synthesize(phrase, voice=voice)
-    transcript = await wyoming_client.transcribe(audio.to_wav_bytes())
+    result = await wyoming_client.transcribe(audio.to_wav_bytes(), model=model)
 
-    assert fuzzy_text_match(transcript, phrase), (
-        f"Round-trip transcript did not match.\n  expected: {phrase!r}\n  got:      {transcript!r}"
-    )
+    assert_fuzzy_match(result.text, phrase)
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,121 @@
+"""End-to-end integration tests against a real Speaches backend.
+
+Skipped by default. To run:
+
+    docker compose -f docker-compose.speaches-cpu.yml up -d speaches
+    pytest -m integration
+
+Or, if Speaches is already running on localhost:8000, just `pytest -m integration`.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+import pytest
+from e2e_helpers import WyomingTestClient, fuzzy_text_match
+
+pytestmark = pytest.mark.integration
+
+MIN_TTS_PCM_BYTES = 8000
+
+
+def _first_voice_name(info) -> str | None:
+    for tts_program in info.tts:
+        if tts_program.voices:
+            return tts_program.voices[0].name
+    return None
+
+
+@pytest.mark.asyncio
+async def test_describe_returns_speaches_models(wyoming_client: WyomingTestClient) -> None:
+    info = await wyoming_client.describe()
+
+    assert info.asr, "Info should advertise at least one ASR program"
+    assert any(model.name for prog in info.asr for model in prog.models), "ASR program should list a model"
+    assert info.tts, "Info should advertise at least one TTS program"
+    assert _first_voice_name(info) is not None, "TTS program should list at least one voice"
+
+
+@pytest.mark.asyncio
+async def test_tts_structural(wyoming_client: WyomingTestClient) -> None:
+    info = await wyoming_client.describe()
+    voice = _first_voice_name(info)
+
+    audio = await wyoming_client.synthesize("Hello, this is a test.", voice=voice)
+
+    assert audio.chunk_count >= 1
+    assert audio.rate > 0
+    assert audio.width == 2
+    assert audio.channels in (1, 2)
+    assert len(audio.pcm) >= MIN_TTS_PCM_BYTES, (
+        f"TTS produced suspiciously little audio: {len(audio.pcm)} bytes"
+    )
+
+    with wave.open(io.BytesIO(audio.to_wav_bytes()), "rb") as wav:
+        assert wav.getframerate() == audio.rate
+        assert wav.getnchannels() == audio.channels
+        assert wav.getsampwidth() == audio.width
+
+
+@pytest.mark.asyncio
+async def test_tts_streaming_structural(wyoming_client: WyomingTestClient) -> None:
+    info = await wyoming_client.describe()
+    voice = _first_voice_name(info)
+
+    audio = await wyoming_client.synthesize_streaming("Hello, this is a streaming test.", voice=voice)
+
+    assert audio.chunk_count >= 1
+    assert len(audio.pcm) >= MIN_TTS_PCM_BYTES
+
+
+@pytest.mark.asyncio
+async def test_stt_from_synthesized_audio(wyoming_client: WyomingTestClient) -> None:
+    """The killer test: synthesize text, transcribe it, assert the loop closes.
+
+    No human listening required - if TTS produces silence or STT returns
+    garbage, fuzzy_text_match will catch it.
+    """
+    info = await wyoming_client.describe()
+    voice = _first_voice_name(info)
+    phrase = "The quick brown fox jumps over the lazy dog."
+
+    audio = await wyoming_client.synthesize(phrase, voice=voice)
+    transcript = await wyoming_client.transcribe(audio.to_wav_bytes())
+
+    assert transcript.strip(), "STT returned empty transcript"
+    assert fuzzy_text_match(transcript, phrase), (
+        f"Round-trip transcript did not match.\n  expected: {phrase!r}\n  got:      {transcript!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stt_round_trip_short_phrase(wyoming_client: WyomingTestClient) -> None:
+    info = await wyoming_client.describe()
+    voice = _first_voice_name(info)
+    phrase = "Turn on the kitchen lights."
+
+    audio = await wyoming_client.synthesize(phrase, voice=voice)
+    transcript = await wyoming_client.transcribe(audio.to_wav_bytes())
+
+    assert fuzzy_text_match(transcript, phrase), (
+        f"Round-trip transcript did not match.\n  expected: {phrase!r}\n  got:      {transcript!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_autodetection_speaches(wyoming_client_autodetect: WyomingTestClient) -> None:
+    """Server started without STT_BACKEND/TTS_BACKEND should still come up.
+
+    The autodetection probe targets the real Speaches /models endpoint, so a
+    successful Describe + working synthesis proves the SPEACHES branch was
+    selected and configured correctly.
+    """
+    info = await wyoming_client_autodetect.describe()
+    assert info.asr, "Autodetected server should still advertise ASR"
+    assert info.tts, "Autodetected server should still advertise TTS"
+
+    voice = _first_voice_name(info)
+    audio = await wyoming_client_autodetect.synthesize("Autodetect smoke test.", voice=voice)
+    assert len(audio.pcm) >= MIN_TTS_PCM_BYTES

--- a/tests/test_e2e_helpers.py
+++ b/tests/test_e2e_helpers.py
@@ -1,0 +1,9 @@
+from e2e_helpers import fuzzy_text_match
+
+
+def test_fuzzy_text_match_accepts_punctuation_and_case_differences():
+    assert fuzzy_text_match("turn on the kitchen lights", "Turn on the kitchen lights.")
+
+
+def test_fuzzy_text_match_rejects_short_substring_match():
+    assert not fuzzy_text_match("lights", "Turn on the kitchen lights.")

--- a/tests/test_e2e_helpers.py
+++ b/tests/test_e2e_helpers.py
@@ -1,4 +1,7 @@
-from e2e_helpers import fuzzy_text_match
+"""Unit tests for the e2e helper utilities (run in the default suite)."""
+
+import pytest
+from e2e_helpers import fuzzy_match, fuzzy_text_match
 
 
 def test_fuzzy_text_match_accepts_punctuation_and_case_differences():
@@ -7,3 +10,42 @@ def test_fuzzy_text_match_accepts_punctuation_and_case_differences():
 
 def test_fuzzy_text_match_rejects_short_substring_match():
     assert not fuzzy_text_match("lights", "Turn on the kitchen lights.")
+
+
+def test_fuzzy_match_reports_score_and_coverage():
+    result = fuzzy_match("turn on the kitchen lights", "Turn on the kitchen lights.")
+    assert result.matched
+    assert result.score == 100.0
+    assert result.coverage == pytest.approx(1.0)
+    assert result.normalized_expected == "turn on the kitchen lights"
+    assert result.normalized_transcript == "turn on the kitchen lights"
+
+
+def test_fuzzy_match_coverage_rejection_reports_details():
+    result = fuzzy_match("lights", "Turn on the kitchen lights.")
+    assert not result.matched
+    assert result.coverage < 0.75
+    # partial_ratio itself is perfect - coverage is what rejects it.
+    assert result.score == 100.0
+
+
+def test_fuzzy_match_tolerates_minor_mishearing():
+    assert fuzzy_text_match(
+        "the quick brown fox jumped over the lazy dog", "The quick brown fox jumps over the lazy dog."
+    )
+
+
+@pytest.mark.parametrize(
+    ("transcript", "expected"),
+    [
+        ("", "Turn on the kitchen lights."),
+        ("turn on the kitchen lights", ""),
+        ("", ""),
+        ("...", "Turn on the kitchen lights."),  # normalizes to empty
+    ],
+)
+def test_fuzzy_match_empty_inputs_never_match(transcript: str, expected: str):
+    result = fuzzy_match(transcript, expected)
+    assert not result.matched
+    assert result.score == 0.0
+    assert result.coverage == 0.0

--- a/tests/test_e2e_negative.py
+++ b/tests/test_e2e_negative.py
@@ -1,0 +1,53 @@
+"""Negative end-to-end tests: the server's rejection contract.
+
+wyoming_openai rejects unknown models/voices by returning False from its event
+handler, which makes the wyoming server close the TCP connection without any
+error event. These tests codify that contract by requiring the connection
+closure specifically: if a future change makes the server answer with an error
+event, hang, or otherwise stop closing the socket, they fail loudly
+(WyomingTimeoutError or an unexpected-event error) so the contract change is a
+conscious one.
+
+Each test uses a fresh connection (a dead connection must not poison the
+shared client fixture) and a short event timeout.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+import pytest
+from e2e_helpers import WyomingServerClosedError, WyomingTestClient
+
+pytestmark = pytest.mark.integration
+
+NEGATIVE_EVENT_TIMEOUT_SECONDS = 10.0
+
+
+@pytest.mark.asyncio
+async def test_unknown_voice_closes_connection(wyoming_endpoint: tuple[str, int]) -> None:
+    host, port = wyoming_endpoint
+    async with WyomingTestClient(
+        host=host, port=port, event_timeout=NEGATIVE_EVENT_TIMEOUT_SECONDS
+    ) as client:
+        with pytest.raises(WyomingServerClosedError):
+            await client.synthesize("hello", voice="definitely-not-a-voice (nope)")
+
+
+@pytest.mark.asyncio
+async def test_unknown_stt_model_closes_connection(wyoming_endpoint: tuple[str, int]) -> None:
+    host, port = wyoming_endpoint
+    # Any WAV payload will do; the server should reject at the Transcribe event.
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(16000)
+        wav.writeframes(b"\x00\x00" * 16000)
+
+    async with WyomingTestClient(
+        host=host, port=port, event_timeout=NEGATIVE_EVENT_TIMEOUT_SECONDS
+    ) as client:
+        with pytest.raises(WyomingServerClosedError):
+            await client.transcribe(buffer.getvalue(), model="definitely-not-a-model")


### PR DESCRIPTION
## Summary

Add an end-to-end integration test suite that synthesizes speech through the real proxy, transcribes it back, and fuzzy-matches the transcript, running in CI against a CPU-only Speaches container.

## Details

- `tests/test_e2e.py` drives a real `wyoming_openai` server over TCP via `WyomingTestClient` (wrapping `wyoming.client.AsyncTcpClient`): a 4-phrase parametrized round-trip corpus, streaming-synthesis round trip, explicit-model transcribe, structural TTS checks, and protocol event-ordering assertions. `tests/test_e2e_negative.py` codifies the silent-disconnect rejection contract for unknown models/voices.
- E2e-only container config lives in a `docker-compose.e2e.yml` overlay (smaller `Systran/faster-distil-whisper-small.en` model, containerized proxy service); `docker-compose.speaches-cpu.yml` keeps general-purpose defaults.
- Tests are gated behind an `integration` marker and skipped by default, so the unit suite and existing `test.yml` matrix are unaffected. Fixtures reuse a healthy Speaches on `localhost:8000`, auto-start the compose stack otherwise, and skip cleanly without Docker. `WYOMING_E2E_URI` targets an external proxy instead of spawning a subprocess.
- New `Integration` workflow runs two parallel jobs: the full suite against a subprocess proxy, and a `smoke` subset against the freshly built Docker image. Hugging Face models are cached with a restore/save split (`restore-keys` fallback, `always()` save so failed cold runs still cache). Failure runs upload Speaches/proxy logs and the synthesized WAVs for human listening.
- The test client hardens against hangs: per-event and per-operation timeouts, and disconnects normalized to `WyomingServerClosedError` on both read and write paths.
- Realtime models (`STT_REALTIME_MODELS`) are intentionally out of scope - Speaches has no realtime websocket API.

## Testing

- `pytest` (unit suite): 143 passed, integration tests deselected; `ruff check .` and `pyright` clean
- `pytest -m integration -v --timeout=180` against local Docker Desktop: all 12 tests pass (~12s warm), including all four round-trip phrases and both negative tests
- Container smoke lane locally: built `wyoming_openai:e2e`, started the layered compose stack, `WYOMING_E2E_URI=tcp://127.0.0.1:10300 pytest -m "integration and smoke"`: 3 passed
- Verified `Systran/faster-distil-whisper-small.en` loads in Speaches 0.9.0-rc.3 via `/v1/models` and a live transcription

🤖 Generated with [Claude Code](https://claude.com/claude-code)